### PR TITLE
feat(ui): add Jewel theme — 6th-gen console visual synthesis

### DIFF
--- a/context/spec/jewel-theme/spec.md
+++ b/context/spec/jewel-theme/spec.md
@@ -1,0 +1,217 @@
+>[toc]
+
+# Jewel — Synthesized Y2K Theme
+
+
+Jewel is a selectable theme for SavePoint that distills the shared DNA of the three 6th-generation consoles — **PS2**, **GameCube**, and **Original Xbox** — into a single cohesive visual language. It is not a homage to any one console. It is the synthesis of what all three had in common: **a UI treated as a living, diegetic machine that's happy to see you.**
+
+
+## Status
+
+---
+
+- **State:** experimental theme, opt-in via theme toggle (alongside `light`, `dark`, `system`)
+- **Replaces:** supersedes the current `y2k` experimental theme
+- **Scope:** token layer + utility classes + progressive surface opt-in
+- **Non-goals:** replacing `light`/`dark` as defaults, full rebrand, sound layer (deferred)
+
+
+## The Shared DNA
+
+
+Three consoles, one common soul:
+
+1. **Optimistic futurism.** The future is exciting and clean — never dystopian, glitchy, or distressed.
+2. **Diegetic UI.** The interface is the machine, not an overlay on the content.
+3. **Chrome, glass, neon — the material trinity.** Chrome is chassis. Glass is panel. Neon is emitted light. Each material has one job and never impersonates another.
+4. **Light has a source.** Glow emanates from a point with direction and falloff — never uniform, never arbitrary.
+5. **Idle breathes.** Hero elements pulse, drift, or shimmer on a slow ambient cycle. The machine is alive even when untouched.
+6. **Transitions are ceremonies.** Nothing snaps. Unfold, rise, sweep, bloom.
+7. **Pre-rendered 3D objects as primitives.** UI elements are treated as objects in space — z-axis is a first-class citizen.
+
+
+## Seven Principles
+
+
+These are laws. Every token, utility, and component obeys them.
+
+| # | Principle | Forbids |
+|---|---|---|
+| 1 | Every surface is an object with weight | Flat rectangles, 1px borders with no backing |
+| 2 | Light has a direction and a source | Uniform neon outlines, arbitrary text-shadow |
+| 3 | Chrome frames, glass reveals, neon emits | Neon borders, hard-edged glass, chrome used as accent |
+| 4 | Idle breathes (respecting `prefers-reduced-motion`) | Static hero elements, frozen stats |
+| 5 | Transitions are ceremonies | `display: none` → `block`, instant state swaps |
+| 6 | Sound is optional but structural (deferred) | Decorative chirps, random click sounds |
+| 7 | Optimism is the mood | Gritty textures, ironic distress, glitch effects |
+
+
+## Token System
+
+
+Four ambient colors (green, indigo, pearl) plus **one ceremonial color** (magenta-spark) that is used rarely and deliberately.
+
+### Palette
+
+---
+
+| Token | Source | Hue | Role |
+|---|---|---|---|
+| `--jewel-core` | OG Xbox | Radioactive green `oklch(0.72 0.22 145)` | Primary emission — the light inside the glass |
+| `--jewel-core-bright` | OG Xbox | Bright green `oklch(0.82 0.28 145)` | Hover / active emission |
+| `--jewel-void` | PS2 | Indigo-black `oklch(0.10 0.035 270)` | Ambient shadow, background, deep surfaces |
+| `--jewel-void-raised` | PS2 | Indigo-black raised `oklch(0.14 0.035 265)` | Elevated background, card backing |
+| `--jewel-pearl` | GameCube | Warm pearl `oklch(0.96 0.015 85)` | Chrome highlight, display text, warm gloss |
+| `--jewel-pearl-dim` | GameCube | Dim pearl `oklch(0.72 0.02 85)` | Secondary text, meta labels |
+| `--jewel-spark` | PS2 □ button | Magenta-pink `oklch(0.68 0.25 340)` | **Ceremonial only — see allowlist below** |
+
+### Supporting tokens
+
+---
+
+| Token | Purpose |
+|---|---|
+| `--jewel-chrome-edge` | Chrome border gradient (pearl → indigo) |
+| `--jewel-glass-fill` | Translucent glass fill with subtle green tint |
+| `--jewel-glass-blur` | Backdrop filter strength (default `blur(16px) saturate(1.4)`) |
+| `--jewel-neon-bloom` | Three-layer point-source glow |
+| `--jewel-scanline-opacity` | CRT scanline strength (default `0.04`) |
+
+
+## Materials
+
+
+Three materials. Each has one job. They never mix roles.
+
+### Chrome
+
+---
+
+The chassis. Frames, edges, dividers, outer shells.
+
+- 1-2px width
+- Gradient: `--jewel-pearl` (top-left) → `--jewel-void` (bottom-right) to imply a cool key light
+- Subtle bevel hint, not skeuomorphic
+- Used on: card edges, nav dividers, modal frames, button outlines
+
+### Glass
+
+---
+
+The window. Content surfaces, panels, cards.
+
+- Translucent fill (40-60% opacity)
+- Backdrop blur + saturation boost
+- Inner shadow for depth
+- Subtle `--jewel-core` tint in fill so emission reads as coming *through* the glass from behind
+- Used on: cards, panels, modals, popovers, sidebar surfaces
+
+### Neon
+
+---
+
+The soul. Emitted light on accents, statuses, active states.
+
+- Always anchored to a **point source** (typically top-left, 30° angle)
+- Always three-layer falloff: tight inner (2px) / medium (10px) / far halo (30px)
+- Color: `--jewel-core` (ambient) or `--jewel-spark` (ceremonial only)
+- Used on: active nav, status pills, hover states, focus rings, achievement moments
+
+
+## Motion Grammar
+
+
+Four named motions. Each from a console. Each with a specific semantic. Rigidly applied.
+
+| Motion | Duration | Source | When |
+|---|---|---|---|
+| **Unfold** | 500ms `ease-out-expo` | GameCube cube-unfold | First load, boot splash, major context switch |
+| **Rise** | 400ms `ease-out-expo` | PS2 tower rise | Numerical reveals, stat counters, list items entering |
+| **Sweep** | 300ms `ease-out-cubic` | Xbox blade sweep | Route/tab changes, sidebar nav, horizontal panel transitions |
+| **Breathe** | 4-8s loop, `ease-in-out` | Common to all | Idle state on hero elements (scale 1.00 ↔ 1.01, glow 0.8 ↔ 1.0) |
+
+### Reduced motion
+
+---
+
+`@media (prefers-reduced-motion: reduce)` disables **breathe** entirely and reduces unfold/rise/sweep to 100ms linear fades. Non-negotiable.
+
+
+## Magenta-Spark Allowlist
+
+
+`--jewel-spark` is ceremonial. It appears maybe 2-3 times per user session. Its rarity is what gives it meaning.
+
+### Allowed
+
+---
+
+- Achievement / milestone unlock toast (full ceremony)
+- "Played" status pill — **only on the game just marked played**, on first render; decays to ambient `--jewel-core` on next page load
+- Rare-game / 100%-completion badge on game cards
+- Boot splash climax frame (single pulse at end of unfold)
+
+### Forbidden
+
+---
+
+- Buttons (any variant)
+- Hover states (general)
+- Links
+- Borders (general)
+- Focus rings
+- Active nav items
+- Error states (use destructive)
+- Form validation
+- Loading indicators
+
+If a new surface wants spark, it earns a line in this allowlist via explicit decision, not drift.
+
+
+## Surface Map
+
+
+How Jewel lands on SavePoint surfaces. Progressive rollout — each row is a slice.
+
+| Surface | Treatment | Priority |
+|---|---|---|
+| **Boot splash** | 1.2s unfold, once per session (`sessionStorage` flag). Indigo void → green point of light rises → unfolds into pearl-chrome wordmark. Skippable on click/key/scroll. | P2 |
+| **Library grid card** | Chrome edge + glass fill + neon bloom from top-left + idle breathing + hover rise | **P0 (prototype)** |
+| **Dashboard stats** | PS2 boot-tower viz. Vertical glass columns rising on mount, breathing on idle. Height = value. | P1 |
+| **Game detail page** | Visor-framed (Metroid Prime homage). Chrome bezel wraps hero. Cover art behind glass. Stats as MJOLNIR-style HUD elements. | P1 |
+| **Status pills** | Glass capsules with internal neon. Each status has own emission color. | P1 |
+| **Route transitions** | Blade sweep on sidebar nav changes | P2 |
+| **Command palette** | Glass panel in indigo void. Pearl chrome frame. Green cursor. Mono entries with tilted meta. | P2 |
+| **Empty states** | GC-warmth moment. Rounded display font. Pearl+indigo, no green. The one place the language softens. | P2 |
+| **Toasts** | Xbox blade slide-in top-right. Chrome frame, glass body, green jewel icon. | P2 |
+| **Achievement unlock** | Full ceremony. Screen dims, magenta-spark rises, bloom sound (deferred). | P3 |
+
+
+## Migration from `y2k`
+
+
+- Add `.jewel` scope to `globals.css` alongside existing `.y2k`
+- Add `jewel` to `next-themes` themes list
+- Add `Jewel` option to `ThemeToggle` component
+- Existing `y2k` theme and utilities remain functional during transition
+- Once all target surfaces are migrated, `.y2k` can be removed in a follow-up
+
+
+## Build Sequence
+
+
+1. **Spec doc** (this file) — source of truth ✅
+2. **Token layer** — `--jewel-*` tokens, `.jewel-chrome` / `.jewel-glass` / `.jewel-neon-*` utilities, `jewel-rise` / `jewel-unfold` / `jewel-sweep` / `jewel-breathe` keyframes
+3. **Theme wiring** — register `jewel` in `next-themes`, add to `ThemeToggle`
+4. **Prototype: library grid card** — the synthesis test. If this holds up, the rest follows
+5. **Review** — does it feel designed or skinned? Adjust principles if needed
+6. **Rollout** — P1 surfaces (dashboard stats, game detail, status pills)
+7. **P2/P3** — boot splash, transitions, command palette, achievement ceremony
+
+
+## Open Questions
+
+
+- Should the `y2k` theme option be kept in the toggle during transition, or replaced outright once Jewel is working?
+- Which font do we pick for the ceremonial "rounded display" role (empty states)? Current candidates: Space Grotesk, Sora, or keep Geist.
+- Does the boot splash play in dev mode, or is it production-only?

--- a/savepoint-app/app/(protected)/dashboard/page.tsx
+++ b/savepoint-app/app/(protected)/dashboard/page.tsx
@@ -62,7 +62,13 @@ export default async function DashboardPage() {
   return (
     <div className="py-3xl">
       <header className="mb-2xl">
-        <h1 className="heading-xl tracking-tight">Welcome back, {username}!</h1>
+        <h1 className="heading-xl y2k-chrome-text y2k:display-lg tracking-tight">
+          Welcome back, {username}!
+        </h1>
+        <div className="y2k-status-bar mt-lg y2k:block hidden" />
+        <p className="text-muted-foreground body-sm mt-md y2k-neon-text y2k:block y2k:tracking-[0.25em] y2k:uppercase y2k:text-xs hidden">
+          System Online
+        </p>
       </header>
 
       <Suspense fallback={<OnboardingSkeleton />}>

--- a/savepoint-app/app/(protected)/dashboard/page.tsx
+++ b/savepoint-app/app/(protected)/dashboard/page.tsx
@@ -76,9 +76,13 @@ export default async function DashboardPage() {
       </Suspense>
 
       <div className="grid gap-2 lg:grid-cols-[1fr_1fr]">
-        <div className="space-y-2">
+        <div className="flex flex-col gap-2">
           <Suspense fallback={<StatsSkeleton />}>
             <DashboardStats userId={userId} />
+          </Suspense>
+
+          <Suspense fallback={<ActivitySkeleton />}>
+            <ActivityFeed userId={userId} />
           </Suspense>
         </div>
 
@@ -96,12 +100,6 @@ export default async function DashboardPage() {
       <div className="mt-2">
         <Suspense fallback={<SectionSkeleton />}>
           <RecentlyAdded userId={userId} />
-        </Suspense>
-      </div>
-
-      <div className="mt-2">
-        <Suspense fallback={<ActivitySkeleton />}>
-          <ActivityFeed userId={userId} />
         </Suspense>
       </div>
     </div>

--- a/savepoint-app/app/(protected)/dashboard/page.tsx
+++ b/savepoint-app/app/(protected)/dashboard/page.tsx
@@ -66,7 +66,7 @@ export default async function DashboardPage() {
           Welcome back, {username}!
         </h1>
         <div className="y2k-status-bar mt-lg y2k:block hidden" />
-        <p className="text-muted-foreground body-sm mt-md y2k-neon-text y2k:block y2k:tracking-[0.25em] y2k:uppercase y2k:text-xs hidden">
+        <p className="text-muted-foreground body-sm mt-md y2k-neon-text y2k-mono y2k-typing-cursor y2k:block y2k:tracking-[0.25em] y2k:uppercase y2k:text-xs hidden">
           System Online
         </p>
       </header>

--- a/savepoint-app/app/games/[slug]/page.tsx
+++ b/savepoint-app/app/games/[slug]/page.tsx
@@ -126,7 +126,7 @@ export default async function GameDetailPage({
             className="mx-auto w-full max-w-[280px] sm:max-w-[240px] lg:sticky lg:top-20 lg:mx-0 lg:max-w-none lg:self-start"
             aria-label="Game details sidebar"
           >
-            <div className="space-y-xl">
+            <div className="space-y-xl jewel-corners jewel:p-2 jewel:rounded-lg">
               <GameCoverImage
                 imageId={game.cover?.image_id}
                 gameTitle={game.name}
@@ -148,23 +148,31 @@ export default async function GameDetailPage({
             aria-label="Game information"
           >
             <header className="space-y-md">
-              <h1 className="heading-xl lg:display-lg tracking-tight">
+              <div
+                aria-hidden
+                className="jewel:flex jewel-meta hidden items-center gap-3 opacity-60"
+              >
+                <span>// GAME.DETAIL</span>
+                <span className="h-px flex-1 bg-[oklch(0.72_0.22_145/0.3)]" />
+                <span>{slug.slice(0, 12).toUpperCase()}</span>
+              </div>
+              <h1 className="heading-xl lg:display-lg jewel-display jewel:tracking-[0.02em] tracking-tight">
                 {game.name}
               </h1>
               <GameReleaseDate firstReleaseDate={game.first_release_date} />
               <GameDescription summary={game.summary} />
               {genres.length > 0 && (
                 <div className="pt-sm flex items-baseline gap-3">
-                  <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-                    Genres
+                  <span className="text-muted-foreground jewel-meta text-xs font-medium tracking-wider uppercase">
+                    // Genres
                   </span>
                   <GenreBadges genres={genres} />
                 </div>
               )}
               {platforms.length > 0 && (
                 <div className="flex items-baseline gap-3">
-                  <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-                    Platforms
+                  <span className="text-muted-foreground jewel-meta text-xs font-medium tracking-wider uppercase">
+                    // Platforms
                   </span>
                   <PlatformBadges platforms={platforms} />
                 </div>

--- a/savepoint-app/features/dashboard/ui/dashboard-game-section.tsx
+++ b/savepoint-app/features/dashboard/ui/dashboard-game-section.tsx
@@ -36,7 +36,7 @@ export function DashboardGameSection({
   return (
     <Card variant="flat" className={cn("p-lg overflow-hidden", className)}>
       <div className="mb-lg flex items-center justify-between">
-        <h2 className="y2k-neon-text y2k:tracking-[0.15em] y2k:uppercase y2k-neon-underline text-sm font-semibold tracking-tight">
+        <h2 className="y2k-neon-text y2k:tracking-[0.15em] y2k:uppercase y2k-neon-underline y2k-section-marker y2k-mono text-sm font-semibold tracking-tight">
           {title}
         </h2>
         {items.length > 0 &&

--- a/savepoint-app/features/dashboard/ui/dashboard-game-section.tsx
+++ b/savepoint-app/features/dashboard/ui/dashboard-game-section.tsx
@@ -36,7 +36,9 @@ export function DashboardGameSection({
   return (
     <Card variant="flat" className={cn("p-lg overflow-hidden", className)}>
       <div className="mb-lg flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
+        <h2 className="y2k-neon-text y2k:tracking-[0.15em] y2k:uppercase y2k-neon-underline text-sm font-semibold tracking-tight">
+          {title}
+        </h2>
         {items.length > 0 &&
           (totalCount === undefined || totalCount > items.length) && (
             <Button variant="ghost" size="sm" asChild className="h-auto p-0">

--- a/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
+++ b/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
@@ -24,15 +24,20 @@ const STATUS_CSS_MAP: Record<string, string> = {
 
 export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
   return (
-    <Card variant="elevated" className="p-xl overflow-hidden">
+    <Card
+      variant="elevated"
+      className="p-xl y2k-gradient-cyan y2k-border-pulse overflow-hidden"
+    >
       <Link href="/library" className="block">
         <div className="mb-lg flex items-center gap-3">
-          <Library className="text-muted-foreground h-5 w-5" />
-          <span className="text-muted-foreground text-sm font-medium tracking-wider uppercase">
+          <Library className="text-muted-foreground y2k-neon-text h-5 w-5" />
+          <span className="text-muted-foreground y2k-neon-text y2k:tracking-[0.2em] text-sm font-medium tracking-wider uppercase">
             Library
           </span>
         </div>
-        <p className="mb-xs text-5xl font-bold tabular-nums">{stats.total}</p>
+        <p className="mb-xs y2k-chrome-text text-5xl font-bold tabular-nums">
+          {stats.total}
+        </p>
         <p className="text-muted-foreground mb-xl text-sm">Total Games</p>
 
         <div className="mb-lg flex h-2.5 overflow-hidden rounded-full">

--- a/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
+++ b/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
@@ -31,16 +31,18 @@ export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
       <Link href="/library" className="block">
         <div className="mb-lg flex items-center gap-3">
           <Library className="text-muted-foreground y2k-neon-text h-5 w-5" />
-          <span className="text-muted-foreground y2k-neon-text y2k:tracking-[0.2em] text-sm font-medium tracking-wider uppercase">
+          <span className="text-muted-foreground y2k-neon-text y2k-mono y2k:tracking-[0.2em] text-sm font-medium tracking-wider uppercase">
             Library
           </span>
         </div>
-        <p className="mb-xs y2k-chrome-text text-5xl font-bold tabular-nums">
+        <p className="mb-xs y2k-chrome-text y2k:text-6xl text-5xl font-bold tabular-nums">
           {stats.total}
         </p>
-        <p className="text-muted-foreground mb-xl text-sm">Total Games</p>
+        <p className="text-muted-foreground y2k-mono mb-xl text-sm">
+          Total Games
+        </p>
 
-        <div className="mb-lg flex h-2.5 overflow-hidden rounded-full">
+        <div className="mb-lg y2k-progress-glow y2k:h-3 flex h-2.5 overflow-hidden rounded-full">
           {LIBRARY_STATUS_CONFIG.map((statusConfig) => {
             const count = getStatCount(stats, statusConfig.value);
             const pct = stats.total > 0 ? (count / stats.total) * 100 : 0;

--- a/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
+++ b/savepoint-app/features/dashboard/ui/dashboard-stats-cards.tsx
@@ -23,26 +23,62 @@ const STATUS_CSS_MAP: Record<string, string> = {
 };
 
 export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
+  const maxCount = Math.max(
+    ...LIBRARY_STATUS_CONFIG.map((s) => getStatCount(stats, s.value)),
+    1
+  );
+
   return (
     <Card
       variant="elevated"
-      className="p-xl y2k-gradient-cyan y2k-border-pulse overflow-hidden"
+      className="p-xl y2k-gradient-cyan y2k-border-pulse jewel-breathe-slow overflow-hidden"
     >
       <Link href="/library" className="block">
         <div className="mb-lg flex items-center gap-3">
-          <Library className="text-muted-foreground y2k-neon-text h-5 w-5" />
-          <span className="text-muted-foreground y2k-neon-text y2k-mono y2k:tracking-[0.2em] text-sm font-medium tracking-wider uppercase">
-            Library
+          <Library className="text-muted-foreground y2k-neon-text jewel-neon-text h-5 w-5" />
+          <span className="text-muted-foreground y2k-neon-text y2k-mono y2k:tracking-[0.2em] jewel-meta jewel:text-[0.72rem] text-sm font-medium tracking-wider uppercase">
+            // LIBRARY
           </span>
         </div>
-        <p className="mb-xs y2k-chrome-text y2k:text-6xl text-5xl font-bold tabular-nums">
+        <p className="mb-xs y2k-chrome-text y2k:text-6xl jewel:text-6xl jewel-neon-text jewel:tracking-[-0.02em] text-5xl font-bold tabular-nums">
           {stats.total}
         </p>
-        <p className="text-muted-foreground y2k-mono mb-xl text-sm">
+        <p className="text-muted-foreground y2k-mono jewel-meta mb-xl text-sm">
           Total Games
         </p>
 
-        <div className="mb-lg y2k-progress-glow y2k:h-3 flex h-2.5 overflow-hidden rounded-full">
+        {/* Jewel: PS2 boot-tower visualization — vertical glass columns rising by count.
+            Hidden in non-jewel themes, which keep the original horizontal progress bar. */}
+        <div
+          aria-hidden
+          className="jewel:flex mb-lg hidden items-end justify-between gap-3 h-24"
+        >
+          {LIBRARY_STATUS_CONFIG.map((statusConfig, i) => {
+            const count = getStatCount(stats, statusConfig.value);
+            const heightPct = (count / maxCount) * 100;
+            return (
+              <div
+                key={statusConfig.value}
+                className="jewel-tower group/tower relative flex-1"
+                style={{
+                  ["--tower-h" as string]: `${heightPct}%`,
+                  animationDelay: `${i * 120}ms`,
+                }}
+              >
+                <div
+                  className="jewel-tower-fill"
+                  style={{
+                    backgroundColor: `var(--status-${STATUS_CSS_MAP[statusConfig.value]})`,
+                  }}
+                />
+                <span className="jewel-tower-count">{count}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Non-jewel themes keep the horizontal progress bar */}
+        <div className="mb-lg y2k-progress-glow y2k:h-3 jewel:hidden flex h-2.5 overflow-hidden rounded-full">
           {LIBRARY_STATUS_CONFIG.map((statusConfig) => {
             const count = getStatCount(stats, statusConfig.value);
             const pct = stats.total > 0 ? (count / stats.total) * 100 : 0;
@@ -69,12 +105,12 @@ export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
                 className="flex items-center gap-1.5"
               >
                 <div
-                  className="h-2 w-2 rounded-full"
+                  className="jewel-dot h-2 w-2 rounded-full"
                   style={{
                     backgroundColor: `var(--status-${STATUS_CSS_MAP[statusConfig.value]})`,
                   }}
                 />
-                <span className="text-muted-foreground text-xs">
+                <span className="text-muted-foreground jewel-meta jewel:text-[0.64rem] text-xs">
                   {getStatusLabel(statusConfig.value)}{" "}
                   <span className="text-foreground font-medium tabular-nums">
                     {count}

--- a/savepoint-app/features/library/ui/library-card.tsx
+++ b/savepoint-app/features/library/ui/library-card.tsx
@@ -57,7 +57,7 @@ export const LibraryCard = memo(function LibraryCard({
 
   const cardContent = (
     <>
-      <div className="relative overflow-hidden rounded-lg">
+      <div className="y2k:ring-primary/25 y2k:group-hover:ring-primary/60 y2k:ring-1 y2k:transition-all y2k:duration-300 y2k:group-hover:shadow-[0_0_20px_oklch(0.78_0.18_195/0.35),0_0_40px_oklch(0.78_0.18_195/0.1)] y2k:group-hover:scale-[1.02] relative overflow-hidden rounded-lg">
         <GameCoverImage
           imageId={coverImageId}
           gameTitle={game.title}

--- a/savepoint-app/features/library/ui/library-card.tsx
+++ b/savepoint-app/features/library/ui/library-card.tsx
@@ -57,7 +57,26 @@ export const LibraryCard = memo(function LibraryCard({
 
   const cardContent = (
     <>
-      <div className="y2k:ring-primary/25 y2k:group-hover:ring-primary/60 y2k:ring-1 y2k:transition-all y2k:duration-300 y2k:group-hover:shadow-[0_0_20px_oklch(0.72_0.22_145/0.35),0_0_40px_oklch(0.72_0.22_145/0.1)] y2k:group-hover:scale-[1.02] relative overflow-hidden rounded-lg">
+      <div
+        className={cn(
+          "relative overflow-hidden rounded-lg",
+          // Y2K legacy treatment
+          "y2k:ring-primary/25 y2k:group-hover:ring-primary/60 y2k:ring-1 y2k:transition-all y2k:duration-300 y2k:group-hover:shadow-[0_0_20px_oklch(0.72_0.22_145/0.35),0_0_40px_oklch(0.72_0.22_145/0.1)] y2k:group-hover:scale-[1.02]",
+          // Jewel: chrome edge + glass inner tint + neon bloom from top-left + ceremonial hover
+          // (Custom classes self-scope via `.jewel .jewel-*` CSS rules — no variant prefix needed)
+          "jewel-chrome-thin jewel-glass jewel-neon-bloom jewel-hover-rise jewel-corners",
+          // Staggered ambient breathing — slow, per-card offset
+          !isMobile && "jewel-breathe-slow"
+        )}
+        style={
+          !isMobile
+            ? ({
+                // Stagger breathe start so the grid doesn't pulse in unison
+                animationDelay: `${(staggerIndex * 220) % 2000}ms`,
+              } as React.CSSProperties)
+            : undefined
+        }
+      >
         <GameCoverImage
           imageId={coverImageId}
           gameTitle={game.title}
@@ -74,7 +93,7 @@ export const LibraryCard = memo(function LibraryCard({
               variant={statusConfig.badgeVariant}
               role="status"
               aria-label={`Status: ${badgeLabel}`}
-              className="shadow-paper-sm backdrop-blur-sm"
+              className="shadow-paper-sm jewel-glass-strong jewel-neon-text jewel:border-primary/40 backdrop-blur-sm"
             >
               {badgeLabel}
             </Badge>
@@ -82,7 +101,21 @@ export const LibraryCard = memo(function LibraryCard({
         )}
       </div>
 
-      <p className="body-sm mt-sm text-foreground line-clamp-2 font-medium">
+      {/* Jewel: tactical meta strip — lives BELOW the cover, not inside it,
+          so it doesn't collide with the hover action bar */}
+      <div
+        aria-hidden
+        className="jewel:flex mt-1.5 hidden items-center justify-between gap-2"
+      >
+        <span className="jewel-meta truncate text-[0.58rem] tracking-[0.14em] opacity-60">
+          // {game.slug.slice(0, 14)}
+        </span>
+        <span className="jewel-meta-tilt text-[0.58rem] opacity-50">
+          {String(index + 1).padStart(3, "0")}
+        </span>
+      </div>
+
+      <p className="body-sm mt-sm text-foreground jewel-display jewel:mt-1 jewel:text-[0.75rem] jewel:font-normal jewel:leading-[1.25] jewel:tracking-[0.04em] line-clamp-2 font-medium">
         {game.title}
       </p>
 

--- a/savepoint-app/features/library/ui/library-card.tsx
+++ b/savepoint-app/features/library/ui/library-card.tsx
@@ -57,7 +57,7 @@ export const LibraryCard = memo(function LibraryCard({
 
   const cardContent = (
     <>
-      <div className="y2k:ring-primary/25 y2k:group-hover:ring-primary/60 y2k:ring-1 y2k:transition-all y2k:duration-300 y2k:group-hover:shadow-[0_0_20px_oklch(0.78_0.18_195/0.35),0_0_40px_oklch(0.78_0.18_195/0.1)] y2k:group-hover:scale-[1.02] relative overflow-hidden rounded-lg">
+      <div className="y2k:ring-primary/25 y2k:group-hover:ring-primary/60 y2k:ring-1 y2k:transition-all y2k:duration-300 y2k:group-hover:shadow-[0_0_20px_oklch(0.72_0.22_145/0.35),0_0_40px_oklch(0.72_0.22_145/0.1)] y2k:group-hover:scale-[1.02] relative overflow-hidden rounded-lg">
         <GameCoverImage
           imageId={coverImageId}
           gameTitle={game.title}

--- a/savepoint-app/features/library/ui/library-filters.tsx
+++ b/savepoint-app/features/library/ui/library-filters.tsx
@@ -90,7 +90,7 @@ export function LibraryFilters() {
   }, []);
 
   useEffect(() => {
-    const currentSearch = searchParams.get("search");
+    const currentSearch = searchParams.get("search") ?? "";
     if (debouncedSearch !== currentSearch) {
       updateFilter("search", debouncedSearch || undefined);
     }

--- a/savepoint-app/features/library/ui/library-page-view.tsx
+++ b/savepoint-app/features/library/ui/library-page-view.tsx
@@ -13,7 +13,7 @@ export function LibraryPageView({ isSteamConnected }: LibraryPageViewProps) {
   return (
     <div className="py-2xl container mx-auto">
       <div className="mb-xl gap-lg flex flex-col sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="heading-lg">Library</h1>
+        <h1 className="heading-lg y2k-chrome-text">Library</h1>
         {isSteamConnected && (
           <Button asChild variant="default" size="sm">
             <Link href="/steam/games">

--- a/savepoint-app/features/profile/ui/profile-view.tsx
+++ b/savepoint-app/features/profile/ui/profile-view.tsx
@@ -20,9 +20,21 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
 
   return (
     <div className="space-y-2xl">
+      <div
+        aria-hidden
+        className="jewel:flex jewel-meta hidden items-center gap-3 opacity-60"
+      >
+        <span>// PROFILE.VIEW</span>
+        <span className="h-px flex-1 bg-[oklch(0.72_0.22_145/0.3)]" />
+        <span>
+          {(profile.username ?? profile.email ?? "USER")
+            .slice(0, 16)
+            .toUpperCase()}
+        </span>
+      </div>
       <div className="gap-xl flex flex-col sm:flex-row sm:items-center sm:justify-between">
         <div className="gap-lg flex items-center">
-          <div className="shrink-0">
+          <div className="jewel-corners jewel-neon-bloom shrink-0 rounded-lg">
             {profile.image ? (
               <Image
                 width={80}
@@ -30,11 +42,11 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
                 priority
                 src={profile.image}
                 alt={`${displayName}'s avatar`}
-                className="ring-border/50 h-20 w-20 rounded-lg object-cover ring-1"
+                className="ring-border/50 jewel:ring-primary/40 h-20 w-20 rounded-lg object-cover ring-1"
               />
             ) : (
               <div
-                className="bg-primary/10 text-primary flex h-20 w-20 items-center justify-center rounded-lg text-2xl font-semibold"
+                className="bg-primary/10 text-primary jewel-glass-strong jewel-neon-text flex h-20 w-20 items-center justify-center rounded-lg text-2xl font-semibold"
                 data-testid="profile-avatar-placeholder"
               >
                 {displayName.charAt(0).toUpperCase()}
@@ -42,8 +54,10 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
             )}
           </div>
           <div className="flex-1">
-            <h1 className="heading-xl tracking-tight">{displayName}</h1>
-            <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-2 text-sm">
+            <h1 className="heading-xl jewel-display jewel:tracking-[0.06em] tracking-tight">
+              {displayName}
+            </h1>
+            <div className="text-muted-foreground jewel-meta jewel:text-[0.68rem] mt-1 flex flex-wrap items-center gap-2 text-sm">
               {profile.email && (
                 <>
                   <span>{profile.email}</span>
@@ -68,7 +82,7 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
 
       {statusEntries.length > 0 && totalGames > 0 && (
         <div data-testid="profile-stats-grid">
-          <div className="mb-lg flex h-3 overflow-hidden rounded-full">
+          <div className="mb-lg jewel-progress-glow flex h-3 overflow-hidden rounded-full">
             {statusEntries.map(([status, count]) => {
               const percentage =
                 totalGames > 0 ? (count / totalGames) * 100 : 0;
@@ -91,15 +105,34 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
             {statusEntries.map(([status, count]) => {
               const percentage =
                 totalGames > 0 ? Math.round((count / totalGames) * 100) : 0;
+              const statusKey =
+                status === "UP_NEXT" ? "upNext" : status.toLowerCase();
               return (
-                <div key={status}>
+                <div
+                  key={status}
+                  className="jewel:flex jewel:flex-col jewel:gap-1"
+                >
+                  <div className="jewel:flex hidden items-center gap-2">
+                    <span
+                      className="jewel-dot h-2 w-2 rounded-full"
+                      style={{
+                        backgroundColor: `var(--status-${statusKey})`,
+                      }}
+                    />
+                    <span className="jewel-meta text-[0.6rem]">
+                      {statusLabels[status] || status}
+                    </span>
+                  </div>
                   <p
-                    className="text-2xl font-bold tabular-nums"
+                    className="jewel:hidden text-2xl font-bold tabular-nums"
                     data-testid="profile-status-count"
                   >
                     {statusLabels[status] || status}
                   </p>
-                  <p className="text-muted-foreground text-sm">
+                  <p className="jewel:block jewel-neon-text hidden text-3xl font-bold tabular-nums">
+                    {count}
+                  </p>
+                  <p className="text-muted-foreground jewel:hidden text-sm">
                     <span className="text-foreground font-semibold tabular-nums">
                       {count}
                     </span>{" "}
@@ -107,7 +140,18 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
                     <span
                       className="tabular-nums"
                       style={{
-                        color: `var(--status-${status === "UP_NEXT" ? "upNext" : status.toLowerCase()})`,
+                        color: `var(--status-${statusKey})`,
+                      }}
+                    >
+                      {percentage}%
+                    </span>
+                  </p>
+                  <p className="jewel-meta jewel:block hidden text-[0.6rem]">
+                    {count} games ·{" "}
+                    <span
+                      className="tabular-nums"
+                      style={{
+                        color: `var(--status-${statusKey})`,
                       }}
                     >
                       {percentage}%
@@ -122,7 +166,19 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
 
       {profile.stats.recentGames.length > 0 && (
         <div>
-          <h2 className="heading-md mb-lg tracking-tight">Recently Played</h2>
+          <div
+            aria-hidden
+            className="jewel:flex jewel-meta mb-md hidden items-center gap-3 opacity-60"
+          >
+            <span>// RECENT.PLAYS</span>
+            <span className="h-px flex-1 bg-[oklch(0.72_0.22_145/0.25)]" />
+            <span>
+              {String(profile.stats.recentGames.length).padStart(3, "0")}
+            </span>
+          </div>
+          <h2 className="heading-md mb-lg jewel-display jewel:tracking-[0.08em] tracking-tight">
+            Recently Played
+          </h2>
           <div
             className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-7 xl:grid-cols-8"
             data-testid="profile-recent-games-grid"
@@ -134,8 +190,11 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
               return (
                 <div
                   key={game.gameId}
-                  className="animate-fade-in group relative overflow-hidden rounded-lg"
-                  style={{ animationDelay: `${(index + 1) * 50}ms` }}
+                  className="animate-fade-in group jewel-chrome-thin jewel-glass jewel-neon-bloom jewel-hover-rise jewel-corners jewel-breathe-slow relative overflow-hidden rounded-lg"
+                  style={{
+                    animationDelay: `${(index + 1) * 50}ms`,
+                    ["--jewel-stagger" as string]: `${(index * 220) % 2000}ms`,
+                  }}
                   data-testid="profile-recent-game-card"
                 >
                   {game.coverImage ? (
@@ -152,15 +211,15 @@ export function ProfileView({ profile, socialCounts }: ProfileViewProps) {
                       data-testid="profile-game-cover-fallback"
                     />
                   )}
-                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 via-black/60 to-transparent p-3 pt-8">
+                  <div className="jewel:from-[oklch(0.08_0.03_270/0.95)] jewel:via-[oklch(0.08_0.03_270/0.65)] absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 via-black/60 to-transparent p-3 pt-8">
                     <h3
-                      className="line-clamp-2 text-sm font-semibold text-white drop-shadow-md"
+                      className="jewel-display jewel:text-[0.72rem] jewel:tracking-[0.04em] jewel:font-normal line-clamp-2 text-sm font-semibold text-white drop-shadow-md"
                       data-testid="profile-recent-game-title"
                     >
                       {game.title}
                     </h3>
                     <p
-                      className="mt-1 text-xs text-white/60"
+                      className="jewel-meta jewel:text-[0.58rem] mt-1 text-xs text-white/60"
                       data-testid="profile-recent-game-timestamp"
                     >
                       {formatDistanceToNow(new Date(game.lastPlayed), {

--- a/savepoint-app/features/social/ui/activity-feed.tsx
+++ b/savepoint-app/features/social/ui/activity-feed.tsx
@@ -25,7 +25,7 @@ export async function ActivityFeed({ userId }: { userId: string }) {
     const popularItems = popularResult.success ? popularResult.data.items : [];
 
     return (
-      <Card variant="flat">
+      <Card variant="flat" className="flex flex-1 flex-col">
         <CardHeader spacing="comfortable">
           <CardTitle>Activity Feed</CardTitle>
         </CardHeader>
@@ -38,7 +38,7 @@ export async function ActivityFeed({ userId }: { userId: string }) {
   }
 
   return (
-    <Card variant="flat">
+    <Card variant="flat" className="flex flex-1 flex-col">
       <CardHeader spacing="comfortable">
         <CardTitle>Activity Feed</CardTitle>
       </CardHeader>

--- a/savepoint-app/shared/components/theme-toggle.tsx
+++ b/savepoint-app/shared/components/theme-toggle.tsx
@@ -1,18 +1,56 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Sparkles, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/shared/components/ui/button";
+import { cn } from "@/shared/lib/ui/utils";
+
+const THEMES = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "y2k", label: "Y2K", icon: Sparkles },
+  { value: "system", label: "System", icon: Monitor },
+] as const;
+
+function getThemeIcon(theme: string | undefined) {
+  const config = THEMES.find((t) => t.value === theme);
+  return config?.icon ?? Sun;
+}
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    if (open) {
+      document.addEventListener("keydown", handleEsc);
+      return () => document.removeEventListener("keydown", handleEsc);
+    }
+  }, [open]);
 
   if (!mounted) {
     return (
@@ -22,19 +60,55 @@ export function ThemeToggle() {
     );
   }
 
+  const CurrentIcon = getThemeIcon(theme);
+
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-8 w-8"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-    >
-      {theme === "dark" ? (
-        <Sun className="text-muted-foreground hover:text-foreground h-4 w-4 transition-colors" />
-      ) : (
-        <Moon className="text-muted-foreground hover:text-foreground h-4 w-4 transition-colors" />
+    <div ref={menuRef} className="relative">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn(
+          "h-8 w-8",
+          theme === "y2k" && "y2k-text-glow text-primary"
+        )}
+        onClick={() => setOpen(!open)}
+        aria-label="Change theme"
+        aria-expanded={open}
+      >
+        <CurrentIcon className="text-muted-foreground hover:text-foreground h-4 w-4 transition-colors" />
+      </Button>
+
+      {open && (
+        <div
+          className={cn(
+            "border-border bg-popover text-popover-foreground shadow-paper-md absolute top-full right-0 z-50 mt-2 min-w-[140px] rounded-lg border p-1",
+            "animate-scale-in",
+            theme === "y2k" && "y2k-border-glow"
+          )}
+          role="menu"
+        >
+          {THEMES.map(({ value, label, icon: Icon }) => (
+            <button
+              key={value}
+              role="menuitem"
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                "hover:bg-accent hover:text-accent-foreground",
+                theme === value
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground"
+              )}
+              onClick={() => {
+                setTheme(value);
+                setOpen(false);
+              }}
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </button>
+          ))}
+        </div>
       )}
-    </Button>
+    </div>
   );
 }

--- a/savepoint-app/shared/components/theme-toggle.tsx
+++ b/savepoint-app/shared/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Monitor, Moon, Sparkles, Sun } from "lucide-react";
+import { Gem, Monitor, Moon, Sparkles, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
 
@@ -11,6 +11,7 @@ const THEMES = [
   { value: "light", label: "Light", icon: Sun },
   { value: "dark", label: "Dark", icon: Moon },
   { value: "y2k", label: "Y2K", icon: Sparkles },
+  { value: "jewel", label: "Jewel", icon: Gem },
   { value: "system", label: "System", icon: Monitor },
 ] as const;
 
@@ -69,7 +70,8 @@ export function ThemeToggle() {
         size="icon"
         className={cn(
           "h-8 w-8",
-          theme === "y2k" && "y2k-text-glow text-primary"
+          theme === "y2k" && "y2k-text-glow text-primary",
+          theme === "jewel" && "jewel-neon-text"
         )}
         onClick={() => setOpen(!open)}
         aria-label="Change theme"
@@ -83,7 +85,8 @@ export function ThemeToggle() {
           className={cn(
             "border-border bg-popover text-popover-foreground shadow-paper-md absolute top-full right-0 z-50 mt-2 min-w-[140px] rounded-lg border p-1",
             "animate-scale-in",
-            theme === "y2k" && "y2k-border-glow"
+            theme === "y2k" && "y2k-border-glow",
+            theme === "jewel" && "jewel-glass-strong jewel-neon"
           )}
           role="menu"
         >

--- a/savepoint-app/shared/components/ui/badge.tsx
+++ b/savepoint-app/shared/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/shared/lib/ui/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit",
+  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit y2k:shadow-[0_0_8px_currentColor/0.3] y2k:tracking-wider",
   {
     variants: {
       variant: {

--- a/savepoint-app/shared/components/ui/badge.tsx
+++ b/savepoint-app/shared/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/shared/lib/ui/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit y2k:shadow-[0_0_8px_currentColor/0.3] y2k:tracking-wider",
+  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit y2k-badge-glow y2k:tracking-wider y2k:font-semibold",
   {
     variants: {
       variant: {

--- a/savepoint-app/shared/components/ui/badge.tsx
+++ b/savepoint-app/shared/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/shared/lib/ui/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit y2k-badge-glow y2k:tracking-wider y2k:font-semibold",
+  "inline-flex items-center rounded-sm border px-lg py-xs text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 w-fit y2k-badge-glow y2k:tracking-wider y2k:font-semibold jewel-badge",
   {
     variants: {
       variant: {

--- a/savepoint-app/shared/components/ui/button.tsx
+++ b/savepoint-app/shared/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-paper hover:bg-primary/90 hover:shadow-paper-md active:scale-[0.98]",
+          "bg-primary text-primary-foreground shadow-paper hover:bg-primary/90 hover:shadow-paper-md active:scale-[0.98] y2k:shadow-[0_0_12px_oklch(0.78_0.18_195/0.3)] y2k:hover:shadow-[0_0_20px_oklch(0.78_0.18_195/0.4)]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-paper-sm hover:bg-destructive/90 hover:shadow-paper active:scale-[0.98]",
         outline:

--- a/savepoint-app/shared/components/ui/button.tsx
+++ b/savepoint-app/shared/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-paper hover:bg-primary/90 hover:shadow-paper-md active:scale-[0.98] y2k:shadow-[0_0_12px_oklch(0.78_0.18_195/0.3)] y2k:hover:shadow-[0_0_20px_oklch(0.78_0.18_195/0.4)]",
+          "bg-primary text-primary-foreground shadow-paper hover:bg-primary/90 hover:shadow-paper-md active:scale-[0.98] y2k:shadow-[0_0_12px_oklch(0.72_0.22_145/0.3)] y2k:hover:shadow-[0_0_20px_oklch(0.72_0.22_145/0.4)]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-paper-sm hover:bg-destructive/90 hover:shadow-paper active:scale-[0.98]",
         outline:

--- a/savepoint-app/shared/components/ui/card.tsx
+++ b/savepoint-app/shared/components/ui/card.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/shared/lib/ui/utils";
 
 const cardVariants = cva(
-  "rounded-lg border transition-all duration-normal y2k-border-glow y2k:bg-card/70 y2k:backdrop-blur-md",
+  "rounded-lg border transition-all duration-normal y2k-border-glow y2k-corner-brackets y2k:bg-card/70 y2k:backdrop-blur-md",
   {
     variants: {
       variant: {

--- a/savepoint-app/shared/components/ui/card.tsx
+++ b/savepoint-app/shared/components/ui/card.tsx
@@ -3,22 +3,27 @@ import * as React from "react";
 
 import { cn } from "@/shared/lib/ui/utils";
 
-const cardVariants = cva("rounded-lg border transition-all duration-normal", {
-  variants: {
-    variant: {
-      default:
-        "bg-card border-border/10 hover:border-border/25 hover:bg-muted/10",
-      interactive:
-        "bg-card border-border/10 hover:border-border/25 hover:brightness-110 cursor-pointer",
-      elevated: "bg-card border-border/10 shadow-paper hover:shadow-paper-md",
-      flat: "bg-card border-border/10",
-      outlined: "bg-card border-border/20 hover:border-primary/40",
+const cardVariants = cva(
+  "rounded-lg border transition-all duration-normal y2k-border-glow y2k:bg-card/70 y2k:backdrop-blur-md",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-card border-border/10 hover:border-border/25 hover:bg-muted/10 y2k:hover:border-primary/20 y2k-glow-hover",
+        interactive:
+          "bg-card border-border/10 hover:border-border/25 hover:brightness-110 cursor-pointer y2k:hover:border-primary/30 y2k-glow-hover",
+        elevated:
+          "bg-card border-border/10 shadow-paper hover:shadow-paper-md y2k-glow",
+        flat: "bg-card border-border/10",
+        outlined:
+          "bg-card border-border/20 hover:border-primary/40 y2k:border-primary/15",
+      },
     },
-  },
-  defaultVariants: {
-    variant: "default",
-  },
-});
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
 
 const cardHeaderVariants = cva("flex flex-col", {
   variants: {

--- a/savepoint-app/shared/components/ui/card.tsx
+++ b/savepoint-app/shared/components/ui/card.tsx
@@ -4,16 +4,16 @@ import * as React from "react";
 import { cn } from "@/shared/lib/ui/utils";
 
 const cardVariants = cva(
-  "rounded-lg border transition-all duration-normal y2k-border-glow y2k-corner-brackets y2k:bg-card/70 y2k:backdrop-blur-md",
+  "rounded-lg border transition-all duration-normal y2k-border-glow y2k-corner-brackets y2k:bg-card/70 y2k:backdrop-blur-md jewel-glass jewel-neon-bloom jewel-corners",
   {
     variants: {
       variant: {
         default:
           "bg-card border-border/10 hover:border-border/25 hover:bg-muted/10 y2k:hover:border-primary/20 y2k-glow-hover",
         interactive:
-          "bg-card border-border/10 hover:border-border/25 hover:brightness-110 cursor-pointer y2k:hover:border-primary/30 y2k-glow-hover",
+          "bg-card border-border/10 hover:border-border/25 hover:brightness-110 cursor-pointer y2k:hover:border-primary/30 y2k-glow-hover jewel-hover-rise",
         elevated:
-          "bg-card border-border/10 shadow-paper hover:shadow-paper-md y2k-glow",
+          "bg-card border-border/10 shadow-paper hover:shadow-paper-md y2k-glow jewel-hover-rise",
         flat: "bg-card border-border/10",
         outlined:
           "bg-card border-border/20 hover:border-primary/40 y2k:border-primary/15",

--- a/savepoint-app/shared/globals.css
+++ b/savepoint-app/shared/globals.css
@@ -230,87 +230,90 @@
 }
 
 .y2k {
-  /* Base colors - deep Y2K navy */
-  --background: oklch(0.11 0.025 270);
-  --foreground: oklch(0.92 0.01 220);
-  /* Surface colors - frosted glass feel */
-  --card: oklch(0.14 0.02 265);
-  --card-foreground: oklch(0.92 0.01 220);
-  --popover: oklch(0.16 0.02 265);
-  --popover-foreground: oklch(0.92 0.01 220);
-  /* Primary accent - electric neon cyan */
-  --primary: oklch(0.78 0.18 195);
-  --primary-foreground: oklch(0.1 0.02 195);
-  /* Secondary - elevated translucent surface */
-  --secondary: oklch(0.17 0.015 270);
-  --secondary-foreground: oklch(0.88 0.01 220);
+  /* Base colors - Xbox green-black (not pure black, green-tinted) */
+  --background: oklch(0.1 0.035 148);
+  --foreground: oklch(0.88 0.04 145);
+  /* Surface colors - dark green-tinted glass */
+  --card: oklch(0.13 0.04 148);
+  --card-foreground: oklch(0.88 0.04 145);
+  --popover: oklch(0.15 0.04 148);
+  --popover-foreground: oklch(0.88 0.04 145);
+  /* Primary accent - Xbox radioactive green */
+  --primary: oklch(0.72 0.22 145);
+  --primary-foreground: oklch(0.08 0.02 145);
+  /* Secondary - elevated dark green panel */
+  --secondary: oklch(0.15 0.035 148);
+  --secondary-foreground: oklch(0.82 0.04 145);
   /* Muted */
-  --muted: oklch(0.17 0.015 270);
-  --muted-foreground: oklch(0.55 0.02 250);
-  /* Accent - magenta/pink Y2K pop */
-  --accent: oklch(0.18 0.04 320);
-  --accent-foreground: oklch(0.92 0.01 320);
+  --muted: oklch(0.15 0.035 148);
+  --muted-foreground: oklch(0.45 0.06 145);
+  /* Accent - bright green highlight */
+  --accent: oklch(0.16 0.04 145);
+  --accent-foreground: oklch(0.82 0.04 145);
   /* Destructive */
-  --destructive: oklch(0.6 0.22 20);
+  --destructive: oklch(0.55 0.22 25);
   --destructive-foreground: oklch(0.99 0 0);
-  /* Success - neon green (Xbox vibe) */
-  --success: oklch(0.75 0.22 145);
-  --success-foreground: oklch(0.1 0.02 145);
-  /* Warning - amber glow */
-  --warning: oklch(0.82 0.16 75);
+  /* Success - bright Xbox green */
+  --success: oklch(0.78 0.25 145);
+  --success-foreground: oklch(0.08 0.02 145);
+  /* Warning - amber */
+  --warning: oklch(0.78 0.16 75);
   --warning-foreground: oklch(0.12 0.02 75);
-  /* Info - blue plasma */
-  --info: oklch(0.7 0.18 250);
+  /* Info - green-tinted */
+  --info: oklch(0.65 0.15 180);
   --info-foreground: oklch(0.99 0 0);
-  /* Borders - subtle neon edge */
-  --border: oklch(0.22 0.03 260);
-  --input: oklch(0.16 0.02 270);
-  --ring: oklch(0.78 0.18 195);
-  /* Chart colors - neon palette */
-  --chart-1: oklch(0.78 0.18 195);
-  --chart-2: oklch(0.72 0.2 330);
-  --chart-3: oklch(0.75 0.22 145);
-  --chart-4: oklch(0.7 0.18 250);
-  --chart-5: oklch(0.82 0.16 75);
+  /* Borders - green edge */
+  --border: oklch(0.18 0.04 145);
+  --input: oklch(0.12 0.025 150);
+  --ring: oklch(0.72 0.22 145);
+  /* Chart colors */
+  --chart-1: oklch(0.72 0.22 145);
+  --chart-2: oklch(0.65 0.18 165);
+  --chart-3: oklch(0.78 0.25 145);
+  --chart-4: oklch(0.6 0.15 180);
+  --chart-5: oklch(0.78 0.16 75);
   /* Sidebar */
-  --sidebar: oklch(0.09 0.025 270);
-  --sidebar-foreground: oklch(0.88 0.01 220);
-  --sidebar-primary: oklch(0.78 0.18 195);
-  --sidebar-primary-foreground: oklch(0.1 0.02 195);
-  --sidebar-accent: oklch(0.15 0.03 320);
-  --sidebar-accent-foreground: oklch(0.88 0.01 220);
-  --sidebar-border: oklch(0.2 0.025 260);
-  --sidebar-ring: oklch(0.78 0.18 195);
-  /* Shadows - neon glow-infused */
+  --sidebar: oklch(0.06 0.02 150);
+  --sidebar-foreground: oklch(0.82 0.04 145);
+  --sidebar-primary: oklch(0.72 0.22 145);
+  --sidebar-primary-foreground: oklch(0.08 0.02 145);
+  --sidebar-accent: oklch(0.12 0.04 145);
+  --sidebar-accent-foreground: oklch(0.82 0.04 145);
+  --sidebar-border: oklch(0.16 0.04 145);
+  --sidebar-ring: oklch(0.72 0.22 145);
+  /* Shadows - green glow-infused */
   --shadow-paper-sm:
-    0 1px 3px 0 oklch(0 0 0 / 0.4), 0 0 4px 0 oklch(0.78 0.18 195 / 0.05);
+    0 1px 3px 0 oklch(0 0 0 / 0.5), 0 0 4px 0 oklch(0.72 0.22 145 / 0.08);
   --shadow-paper:
-    0 2px 12px 0 oklch(0 0 0 / 0.5), 0 0 8px 0 oklch(0.78 0.18 195 / 0.06);
+    0 2px 12px 0 oklch(0 0 0 / 0.6), 0 0 8px 0 oklch(0.72 0.22 145 / 0.1);
   --shadow-paper-md:
-    0 4px 20px 0 oklch(0 0 0 / 0.55), 0 0 16px 0 oklch(0.78 0.18 195 / 0.08);
+    0 4px 20px 0 oklch(0 0 0 / 0.65),
+    0 0 16px 0 oklch(0.72 0.22 145 / 0.12);
   --shadow-paper-lg:
-    0 8px 40px 0 oklch(0 0 0 / 0.65), 0 0 30px 0 oklch(0.78 0.18 195 / 0.1);
-  /* Y2K-specific tokens */
-  --y2k-glow-cyan: oklch(0.82 0.2 195);
-  --y2k-glow-magenta: oklch(0.7 0.28 330);
-  --y2k-glow-green: oklch(0.8 0.25 145);
-  --y2k-scanline-opacity: 0.07;
-  --y2k-glass-opacity: 0.45;
+    0 8px 40px 0 oklch(0 0 0 / 0.75),
+    0 0 30px 0 oklch(0.72 0.22 145 / 0.15);
+  /* Y2K-specific tokens — Xbox green */
+  --y2k-glow-cyan: oklch(0.72 0.22 145);
+  --y2k-glow-magenta: oklch(0.6 0.18 165);
+  --y2k-glow-green: oklch(0.82 0.28 145);
+  --y2k-scanline-opacity: 0.05;
+  --y2k-glass-opacity: 0.4;
   --y2k-border-glow:
-    0 0 12px oklch(0.78 0.18 195 / 0.5), 0 0 3px oklch(0.78 0.18 195 / 0.7),
-    inset 0 0 8px oklch(0.78 0.18 195 / 0.12);
-  --radius: 0.25rem;
-  /* Status colors - neon vibrant */
-  --status-wishlist: oklch(0.68 0.18 270);
+    0 0 10px oklch(0.72 0.22 145 / 0.45),
+    0 0 3px oklch(0.72 0.22 145 / 0.7),
+    inset 0 0 6px oklch(0.72 0.22 145 / 0.1);
+  --radius: 0.125rem;
+  /* Status colors */
+  --status-wishlist: oklch(0.6 0.15 270);
   --status-wishlist-foreground: oklch(0.99 0 0);
-  --status-shelf: oklch(0.78 0.16 55);
+  --status-shelf: oklch(0.72 0.16 55);
   --status-shelf-foreground: oklch(0.12 0.01 55);
-  --status-upNext: oklch(0.82 0.16 75);
+  --status-upNext: oklch(0.78 0.16 75);
   --status-upNext-foreground: oklch(0.12 0.01 75);
-  --status-playing: oklch(0.78 0.18 195);
-  --status-playing-foreground: oklch(0.1 0.02 195);
-  --status-played: oklch(0.75 0.22 145);
-  --status-played-foreground: oklch(0.1 0.02 145);
+  --status-playing: oklch(0.72 0.22 145);
+  --status-playing-foreground: oklch(0.08 0.02 145);
+  --status-played: oklch(0.65 0.18 165);
+  --status-played-foreground: oklch(0.08 0.02 165);
 }
 
 @theme inline {
@@ -489,16 +492,16 @@
 @keyframes y2k-border-pulse {
   0%,
   100% {
-    border-color: oklch(0.78 0.18 195 / 0.3);
+    border-color: oklch(0.72 0.22 145 / 0.3);
     box-shadow:
-      0 0 6px oklch(0.78 0.18 195 / 0.15),
-      inset 0 0 4px oklch(0.78 0.18 195 / 0.05);
+      0 0 6px oklch(0.72 0.22 145 / 0.15),
+      inset 0 0 4px oklch(0.72 0.22 145 / 0.05);
   }
   50% {
-    border-color: oklch(0.78 0.18 195 / 0.6);
+    border-color: oklch(0.72 0.22 145 / 0.6);
     box-shadow:
-      0 0 18px oklch(0.78 0.18 195 / 0.25),
-      inset 0 0 8px oklch(0.78 0.18 195 / 0.08);
+      0 0 18px oklch(0.72 0.22 145 / 0.25),
+      inset 0 0 8px oklch(0.72 0.22 145 / 0.08);
   }
 }
 
@@ -574,6 +577,27 @@
     @apply bg-background text-foreground;
   }
 
+  .y2k ::selection {
+    background: oklch(0.72 0.22 145 / 0.35);
+    color: oklch(0.95 0.04 145);
+  }
+
+  .y2k ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .y2k ::-webkit-scrollbar-track {
+    background: oklch(0.06 0.03 148);
+  }
+  .y2k ::-webkit-scrollbar-thumb {
+    background: oklch(0.72 0.22 145 / 0.4);
+    border-radius: 0;
+  }
+  .y2k ::-webkit-scrollbar-thumb:hover {
+    background: oklch(0.72 0.22 145 / 0.7);
+    box-shadow: 0 0 4px oklch(0.72 0.22 145 / 0.3);
+  }
+
   .y2k body::before {
     content: "";
     position: fixed;
@@ -599,28 +623,28 @@
     background:
       radial-gradient(
         ellipse 120% 70% at 50% -10%,
-        oklch(0.78 0.18 195 / 0.12),
+        oklch(0.72 0.22 145 / 0.12),
         transparent 50%
       ),
       radial-gradient(
         ellipse 80% 60% at 95% 100%,
-        oklch(0.65 0.25 330 / 0.1),
+        oklch(0.55 0.18 165 / 0.1),
         transparent 45%
       ),
       radial-gradient(
         ellipse 60% 50% at 5% 50%,
-        oklch(0.75 0.22 145 / 0.07),
+        oklch(0.78 0.25 145 / 0.07),
         transparent 45%
       ),
       repeating-linear-gradient(
         0deg,
-        oklch(0.78 0.18 195 / 0.03) 0px,
+        oklch(0.72 0.22 145 / 0.03) 0px,
         transparent 1px,
         transparent 40px
       ),
       repeating-linear-gradient(
         90deg,
-        oklch(0.78 0.18 195 / 0.03) 0px,
+        oklch(0.72 0.22 145 / 0.03) 0px,
         transparent 1px,
         transparent 40px
       );
@@ -1420,14 +1444,14 @@
     background: oklch(0.14 0.02 265 / var(--y2k-glass-opacity, 0.6));
     backdrop-filter: blur(16px) saturate(1.4);
     -webkit-backdrop-filter: blur(16px) saturate(1.4);
-    border: 1px solid oklch(0.78 0.18 195 / 0.12);
+    border: 1px solid oklch(0.72 0.22 145 / 0.12);
   }
 
   .y2k .y2k-glass-strong {
     background: oklch(0.12 0.025 270 / 0.8);
     backdrop-filter: blur(24px) saturate(1.6);
     -webkit-backdrop-filter: blur(24px) saturate(1.6);
-    border: 1px solid oklch(0.78 0.18 195 / 0.2);
+    border: 1px solid oklch(0.72 0.22 145 / 0.2);
   }
 
   .y2k .y2k-glow {
@@ -1436,36 +1460,36 @@
 
   .y2k .y2k-glow-hover:hover {
     box-shadow:
-      0 0 2px oklch(0.78 0.18 195 / 0.6),
-      0 0 12px oklch(0.78 0.18 195 / 0.4),
-      0 0 30px oklch(0.78 0.18 195 / 0.15);
-    border-color: oklch(0.78 0.18 195 / 0.5);
+      0 0 2px oklch(0.72 0.22 145 / 0.6),
+      0 0 12px oklch(0.72 0.22 145 / 0.4),
+      0 0 30px oklch(0.72 0.22 145 / 0.15);
+    border-color: oklch(0.72 0.22 145 / 0.5);
   }
 
   .y2k .y2k-glow-magenta {
-    box-shadow: 0 0 6px oklch(0.65 0.25 330 / 0.3);
+    box-shadow: 0 0 6px oklch(0.55 0.18 165 / 0.3);
   }
 
   .y2k .y2k-glow-green {
-    box-shadow: 0 0 6px oklch(0.75 0.22 145 / 0.3);
+    box-shadow: 0 0 6px oklch(0.78 0.25 145 / 0.3);
   }
 
   .y2k .y2k-text-glow {
     text-shadow:
-      0 0 10px oklch(0.78 0.18 195 / 0.6),
-      0 0 30px oklch(0.78 0.18 195 / 0.2);
+      0 0 10px oklch(0.72 0.22 145 / 0.6),
+      0 0 30px oklch(0.72 0.22 145 / 0.2);
   }
 
   .y2k .y2k-text-glow-magenta {
-    text-shadow: 0 0 8px oklch(0.65 0.25 330 / 0.5);
+    text-shadow: 0 0 8px oklch(0.55 0.18 165 / 0.5);
   }
 
   .y2k .y2k-border-glow {
-    border: 1px solid oklch(0.78 0.18 195 / 0.3);
+    border: 1px solid oklch(0.72 0.22 145 / 0.3);
     box-shadow:
-      inset 0 0 6px oklch(0.78 0.18 195 / 0.06),
-      0 0 10px oklch(0.78 0.18 195 / 0.15),
-      0 0 2px oklch(0.78 0.18 195 / 0.3);
+      inset 0 0 6px oklch(0.72 0.22 145 / 0.06),
+      0 0 10px oklch(0.72 0.22 145 / 0.15),
+      0 0 2px oklch(0.72 0.22 145 / 0.3);
   }
 
   .y2k .y2k-border-pulse {
@@ -1492,7 +1516,7 @@
   .y2k .y2k-gradient-cyan {
     background: linear-gradient(
       135deg,
-      oklch(0.78 0.18 195 / 0.15),
+      oklch(0.72 0.22 145 / 0.15),
       transparent 60%
     );
   }
@@ -1500,7 +1524,7 @@
   .y2k .y2k-gradient-magenta {
     background: linear-gradient(
       135deg,
-      oklch(0.65 0.25 330 / 0.1),
+      oklch(0.55 0.18 165 / 0.1),
       transparent 60%
     );
   }
@@ -1520,12 +1544,12 @@
     background: linear-gradient(
       90deg,
       transparent,
-      oklch(0.78 0.18 195 / 0.4) 15%,
-      oklch(0.78 0.18 195 / 0.8) 50%,
-      oklch(0.78 0.18 195 / 0.4) 85%,
+      oklch(0.72 0.22 145 / 0.4) 15%,
+      oklch(0.72 0.22 145 / 0.8) 50%,
+      oklch(0.72 0.22 145 / 0.4) 85%,
       transparent
     );
-    box-shadow: 0 0 8px oklch(0.78 0.18 195 / 0.3);
+    box-shadow: 0 0 8px oklch(0.72 0.22 145 / 0.3);
   }
 
   .y2k .y2k-bevel {
@@ -1547,45 +1571,45 @@
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
-    filter: drop-shadow(0 0 8px oklch(0.78 0.18 195 / 0.4));
+    filter: drop-shadow(0 0 8px oklch(0.72 0.22 145 / 0.4));
   }
 
   .y2k .y2k-neon-text {
     color: oklch(0.82 0.2 195);
     text-shadow:
-      0 0 4px oklch(0.78 0.18 195 / 0.8),
-      0 0 12px oklch(0.78 0.18 195 / 0.5),
-      0 0 30px oklch(0.78 0.18 195 / 0.3),
-      0 0 50px oklch(0.78 0.18 195 / 0.1);
+      0 0 4px oklch(0.72 0.22 145 / 0.8),
+      0 0 12px oklch(0.72 0.22 145 / 0.5),
+      0 0 30px oklch(0.72 0.22 145 / 0.3),
+      0 0 50px oklch(0.72 0.22 145 / 0.1);
   }
 
   .y2k .y2k-neon-text-magenta {
     color: oklch(0.75 0.25 330);
     text-shadow:
-      0 0 4px oklch(0.65 0.25 330 / 0.8),
-      0 0 12px oklch(0.65 0.25 330 / 0.5),
-      0 0 30px oklch(0.65 0.25 330 / 0.3);
+      0 0 4px oklch(0.55 0.18 165 / 0.8),
+      0 0 12px oklch(0.55 0.18 165 / 0.5),
+      0 0 30px oklch(0.55 0.18 165 / 0.3);
   }
 
   .y2k .y2k-neon-text-green {
     color: oklch(0.8 0.25 145);
     text-shadow:
-      0 0 4px oklch(0.75 0.22 145 / 0.8),
-      0 0 12px oklch(0.75 0.22 145 / 0.5),
-      0 0 30px oklch(0.75 0.22 145 / 0.3);
+      0 0 4px oklch(0.78 0.25 145 / 0.8),
+      0 0 12px oklch(0.78 0.25 145 / 0.5),
+      0 0 30px oklch(0.78 0.25 145 / 0.3);
   }
 
   .y2k .y2k-status-bar {
     height: 2px;
     background: linear-gradient(
       90deg,
-      oklch(0.78 0.18 195),
-      oklch(0.65 0.25 330),
-      oklch(0.75 0.22 145)
+      oklch(0.72 0.22 145),
+      oklch(0.55 0.18 165),
+      oklch(0.78 0.25 145)
     );
     background-size: 200% 100%;
     animation: y2k-gradient-shift 4s ease-in-out infinite;
-    box-shadow: 0 0 12px oklch(0.78 0.18 195 / 0.5);
+    box-shadow: 0 0 12px oklch(0.72 0.22 145 / 0.5);
   }
 
   .y2k .y2k-animated-border {
@@ -1600,10 +1624,10 @@
     border-radius: inherit;
     background: linear-gradient(
       45deg,
-      oklch(0.78 0.18 195),
-      oklch(0.65 0.25 330),
-      oklch(0.75 0.22 145),
-      oklch(0.78 0.18 195)
+      oklch(0.72 0.22 145),
+      oklch(0.55 0.18 165),
+      oklch(0.78 0.25 145),
+      oklch(0.72 0.22 145)
     );
     background-size: 300% 300%;
     animation: y2k-gradient-shift 4s ease infinite;
@@ -1630,10 +1654,10 @@
     height: 2px;
     background: linear-gradient(
       90deg,
-      oklch(0.78 0.18 195),
-      oklch(0.65 0.25 330)
+      oklch(0.72 0.22 145),
+      oklch(0.55 0.18 165)
     );
-    box-shadow: 0 0 8px oklch(0.78 0.18 195 / 0.5);
+    box-shadow: 0 0 8px oklch(0.72 0.22 145 / 0.5);
     border-radius: 1px;
   }
 
@@ -1643,6 +1667,75 @@
 
   .y2k .y2k-hue-shift {
     animation: y2k-hue-rotate 12s linear infinite;
+  }
+
+  .y2k .y2k-corner-brackets {
+    position: relative;
+  }
+  .y2k .y2k-corner-brackets::before,
+  .y2k .y2k-corner-brackets::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .y2k .y2k-corner-brackets::before {
+    top: -1px;
+    left: -1px;
+    border-top: 2px solid oklch(0.72 0.22 145 / 0.8);
+    border-left: 2px solid oklch(0.72 0.22 145 / 0.8);
+    filter: drop-shadow(0 0 3px oklch(0.72 0.22 145 / 0.5));
+  }
+  .y2k .y2k-corner-brackets::after {
+    bottom: -1px;
+    right: -1px;
+    border-bottom: 2px solid oklch(0.72 0.22 145 / 0.5);
+    border-right: 2px solid oklch(0.72 0.22 145 / 0.5);
+    filter: drop-shadow(0 0 3px oklch(0.72 0.22 145 / 0.3));
+  }
+
+  .y2k .y2k-progress-glow {
+    box-shadow: 0 0 8px oklch(0.72 0.22 145 / 0.3);
+    border: 1px solid oklch(0.72 0.22 145 / 0.2);
+    background: oklch(0.06 0.02 148) !important;
+  }
+
+  .y2k .y2k-typing-cursor::after {
+    content: "_";
+    animation: y2k-typing-cursor 1s step-end infinite;
+    color: oklch(0.72 0.22 145);
+    margin-left: 2px;
+  }
+
+  .y2k .y2k-logo-glow {
+    filter: drop-shadow(0 0 6px oklch(0.72 0.22 145 / 0.6))
+      drop-shadow(0 0 14px oklch(0.72 0.22 145 / 0.3));
+  }
+
+  .y2k .y2k-badge-glow {
+    box-shadow:
+      0 0 4px currentColor,
+      0 0 10px oklch(0.72 0.22 145 / 0.2);
+    border: 1px solid oklch(1 0 0 / 0.15);
+  }
+
+  .y2k .y2k-mono {
+    font-family: "Geist Mono", "DM Mono", monospace;
+  }
+
+  .y2k .y2k-section-marker {
+    position: relative;
+    padding-left: 16px;
+  }
+  .y2k .y2k-section-marker::before {
+    content: "//";
+    position: absolute;
+    left: 0;
+    color: oklch(0.72 0.22 145 / 0.5);
+    font-family: "Geist Mono", monospace;
+    font-size: 0.85em;
   }
 
   /* Reduced motion support */

--- a/savepoint-app/shared/globals.css
+++ b/savepoint-app/shared/globals.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *, .y2k *));
+@custom-variant y2k (&:is(.y2k *));
 
 :root {
   /* Base colors - clean light theme */
@@ -228,6 +229,90 @@
   --status-played-foreground: oklch(0.12 0.01 145);
 }
 
+.y2k {
+  /* Base colors - deep Y2K navy */
+  --background: oklch(0.11 0.025 270);
+  --foreground: oklch(0.92 0.01 220);
+  /* Surface colors - frosted glass feel */
+  --card: oklch(0.14 0.02 265);
+  --card-foreground: oklch(0.92 0.01 220);
+  --popover: oklch(0.16 0.02 265);
+  --popover-foreground: oklch(0.92 0.01 220);
+  /* Primary accent - electric neon cyan */
+  --primary: oklch(0.78 0.18 195);
+  --primary-foreground: oklch(0.1 0.02 195);
+  /* Secondary - elevated translucent surface */
+  --secondary: oklch(0.17 0.015 270);
+  --secondary-foreground: oklch(0.88 0.01 220);
+  /* Muted */
+  --muted: oklch(0.17 0.015 270);
+  --muted-foreground: oklch(0.55 0.02 250);
+  /* Accent - magenta/pink Y2K pop */
+  --accent: oklch(0.18 0.04 320);
+  --accent-foreground: oklch(0.92 0.01 320);
+  /* Destructive */
+  --destructive: oklch(0.6 0.22 20);
+  --destructive-foreground: oklch(0.99 0 0);
+  /* Success - neon green (Xbox vibe) */
+  --success: oklch(0.75 0.22 145);
+  --success-foreground: oklch(0.1 0.02 145);
+  /* Warning - amber glow */
+  --warning: oklch(0.82 0.16 75);
+  --warning-foreground: oklch(0.12 0.02 75);
+  /* Info - blue plasma */
+  --info: oklch(0.7 0.18 250);
+  --info-foreground: oklch(0.99 0 0);
+  /* Borders - subtle neon edge */
+  --border: oklch(0.22 0.03 260);
+  --input: oklch(0.16 0.02 270);
+  --ring: oklch(0.78 0.18 195);
+  /* Chart colors - neon palette */
+  --chart-1: oklch(0.78 0.18 195);
+  --chart-2: oklch(0.72 0.2 330);
+  --chart-3: oklch(0.75 0.22 145);
+  --chart-4: oklch(0.7 0.18 250);
+  --chart-5: oklch(0.82 0.16 75);
+  /* Sidebar */
+  --sidebar: oklch(0.09 0.025 270);
+  --sidebar-foreground: oklch(0.88 0.01 220);
+  --sidebar-primary: oklch(0.78 0.18 195);
+  --sidebar-primary-foreground: oklch(0.1 0.02 195);
+  --sidebar-accent: oklch(0.15 0.03 320);
+  --sidebar-accent-foreground: oklch(0.88 0.01 220);
+  --sidebar-border: oklch(0.2 0.025 260);
+  --sidebar-ring: oklch(0.78 0.18 195);
+  /* Shadows - neon glow-infused */
+  --shadow-paper-sm:
+    0 1px 3px 0 oklch(0 0 0 / 0.4), 0 0 4px 0 oklch(0.78 0.18 195 / 0.05);
+  --shadow-paper:
+    0 2px 12px 0 oklch(0 0 0 / 0.5), 0 0 8px 0 oklch(0.78 0.18 195 / 0.06);
+  --shadow-paper-md:
+    0 4px 20px 0 oklch(0 0 0 / 0.55), 0 0 16px 0 oklch(0.78 0.18 195 / 0.08);
+  --shadow-paper-lg:
+    0 8px 40px 0 oklch(0 0 0 / 0.65), 0 0 30px 0 oklch(0.78 0.18 195 / 0.1);
+  /* Y2K-specific tokens */
+  --y2k-glow-cyan: oklch(0.82 0.2 195);
+  --y2k-glow-magenta: oklch(0.7 0.28 330);
+  --y2k-glow-green: oklch(0.8 0.25 145);
+  --y2k-scanline-opacity: 0.07;
+  --y2k-glass-opacity: 0.45;
+  --y2k-border-glow:
+    0 0 12px oklch(0.78 0.18 195 / 0.5), 0 0 3px oklch(0.78 0.18 195 / 0.7),
+    inset 0 0 8px oklch(0.78 0.18 195 / 0.12);
+  --radius: 0.25rem;
+  /* Status colors - neon vibrant */
+  --status-wishlist: oklch(0.68 0.18 270);
+  --status-wishlist-foreground: oklch(0.99 0 0);
+  --status-shelf: oklch(0.78 0.16 55);
+  --status-shelf-foreground: oklch(0.12 0.01 55);
+  --status-upNext: oklch(0.82 0.16 75);
+  --status-upNext-foreground: oklch(0.12 0.01 75);
+  --status-playing: oklch(0.78 0.18 195);
+  --status-playing-foreground: oklch(0.1 0.02 195);
+  --status-played: oklch(0.75 0.22 145);
+  --status-played-foreground: oklch(0.1 0.02 145);
+}
+
 @theme inline {
   /* Font families */
   --font-sans: "Geist", system-ui, sans-serif;
@@ -401,12 +486,144 @@
   }
 }
 
+@keyframes y2k-border-pulse {
+  0%,
+  100% {
+    border-color: oklch(0.78 0.18 195 / 0.3);
+    box-shadow:
+      0 0 6px oklch(0.78 0.18 195 / 0.15),
+      inset 0 0 4px oklch(0.78 0.18 195 / 0.05);
+  }
+  50% {
+    border-color: oklch(0.78 0.18 195 / 0.6);
+    box-shadow:
+      0 0 18px oklch(0.78 0.18 195 / 0.25),
+      inset 0 0 8px oklch(0.78 0.18 195 / 0.08);
+  }
+}
+
+@keyframes y2k-data-stream {
+  0% {
+    background-position: 0% 0%;
+  }
+  100% {
+    background-position: 0% 100%;
+  }
+}
+
+@keyframes y2k-hue-rotate {
+  0% {
+    filter: hue-rotate(0deg);
+  }
+  100% {
+    filter: hue-rotate(360deg);
+  }
+}
+
+@keyframes y2k-gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes y2k-flicker {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  92% {
+    opacity: 1;
+  }
+  93% {
+    opacity: 0.8;
+  }
+  94% {
+    opacity: 1;
+  }
+  96% {
+    opacity: 0.9;
+  }
+  97% {
+    opacity: 1;
+  }
+}
+
+@keyframes y2k-ambient-rotate {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.1);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;
+  }
+
+  .y2k body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      oklch(0 0 0 / var(--y2k-scanline-opacity, 0)) 2px,
+      oklch(0 0 0 / var(--y2k-scanline-opacity, 0)) 4px
+    );
+  }
+
+  .y2k body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    animation: y2k-flicker 8s ease-in-out infinite;
+    background:
+      radial-gradient(
+        ellipse 120% 70% at 50% -10%,
+        oklch(0.78 0.18 195 / 0.12),
+        transparent 50%
+      ),
+      radial-gradient(
+        ellipse 80% 60% at 95% 100%,
+        oklch(0.65 0.25 330 / 0.1),
+        transparent 45%
+      ),
+      radial-gradient(
+        ellipse 60% 50% at 5% 50%,
+        oklch(0.75 0.22 145 / 0.07),
+        transparent 45%
+      ),
+      repeating-linear-gradient(
+        0deg,
+        oklch(0.78 0.18 195 / 0.03) 0px,
+        transparent 1px,
+        transparent 40px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        oklch(0.78 0.18 195 / 0.03) 0px,
+        transparent 1px,
+        transparent 40px
+      );
   }
 }
 
@@ -1197,6 +1414,237 @@
     transition-duration: var(--duration-slower);
   }
 
+  /* Y2K Design System Utilities — scoped to .y2k theme */
+
+  .y2k .y2k-glass {
+    background: oklch(0.14 0.02 265 / var(--y2k-glass-opacity, 0.6));
+    backdrop-filter: blur(16px) saturate(1.4);
+    -webkit-backdrop-filter: blur(16px) saturate(1.4);
+    border: 1px solid oklch(0.78 0.18 195 / 0.12);
+  }
+
+  .y2k .y2k-glass-strong {
+    background: oklch(0.12 0.025 270 / 0.8);
+    backdrop-filter: blur(24px) saturate(1.6);
+    -webkit-backdrop-filter: blur(24px) saturate(1.6);
+    border: 1px solid oklch(0.78 0.18 195 / 0.2);
+  }
+
+  .y2k .y2k-glow {
+    box-shadow: var(--y2k-border-glow);
+  }
+
+  .y2k .y2k-glow-hover:hover {
+    box-shadow:
+      0 0 2px oklch(0.78 0.18 195 / 0.6),
+      0 0 12px oklch(0.78 0.18 195 / 0.4),
+      0 0 30px oklch(0.78 0.18 195 / 0.15);
+    border-color: oklch(0.78 0.18 195 / 0.5);
+  }
+
+  .y2k .y2k-glow-magenta {
+    box-shadow: 0 0 6px oklch(0.65 0.25 330 / 0.3);
+  }
+
+  .y2k .y2k-glow-green {
+    box-shadow: 0 0 6px oklch(0.75 0.22 145 / 0.3);
+  }
+
+  .y2k .y2k-text-glow {
+    text-shadow:
+      0 0 10px oklch(0.78 0.18 195 / 0.6),
+      0 0 30px oklch(0.78 0.18 195 / 0.2);
+  }
+
+  .y2k .y2k-text-glow-magenta {
+    text-shadow: 0 0 8px oklch(0.65 0.25 330 / 0.5);
+  }
+
+  .y2k .y2k-border-glow {
+    border: 1px solid oklch(0.78 0.18 195 / 0.3);
+    box-shadow:
+      inset 0 0 6px oklch(0.78 0.18 195 / 0.06),
+      0 0 10px oklch(0.78 0.18 195 / 0.15),
+      0 0 2px oklch(0.78 0.18 195 / 0.3);
+  }
+
+  .y2k .y2k-border-pulse {
+    animation: y2k-border-pulse 3s ease-in-out infinite;
+  }
+
+  .y2k .y2k-clip-angular {
+    clip-path: polygon(
+      0 8px,
+      8px 0,
+      calc(100% - 8px) 0,
+      100% 8px,
+      100% calc(100% - 8px),
+      calc(100% - 8px) 100%,
+      8px 100%,
+      0 calc(100% - 8px)
+    );
+  }
+
+  .y2k .y2k-corner-cut {
+    clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 0 100%);
+  }
+
+  .y2k .y2k-gradient-cyan {
+    background: linear-gradient(
+      135deg,
+      oklch(0.78 0.18 195 / 0.15),
+      transparent 60%
+    );
+  }
+
+  .y2k .y2k-gradient-magenta {
+    background: linear-gradient(
+      135deg,
+      oklch(0.65 0.25 330 / 0.1),
+      transparent 60%
+    );
+  }
+
+  .y2k .y2k-gradient-chrome {
+    background: linear-gradient(
+      180deg,
+      oklch(0.3 0.01 250),
+      oklch(0.15 0.02 265) 40%,
+      oklch(0.25 0.015 255) 60%,
+      oklch(0.12 0.025 270)
+    );
+  }
+
+  .y2k .y2k-divider {
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      oklch(0.78 0.18 195 / 0.4) 15%,
+      oklch(0.78 0.18 195 / 0.8) 50%,
+      oklch(0.78 0.18 195 / 0.4) 85%,
+      transparent
+    );
+    box-shadow: 0 0 8px oklch(0.78 0.18 195 / 0.3);
+  }
+
+  .y2k .y2k-bevel {
+    border: 1px solid oklch(0.4 0.01 250);
+    border-top-color: oklch(0.5 0.01 250);
+    border-left-color: oklch(0.45 0.01 250);
+    border-bottom-color: oklch(0.15 0.01 250);
+    border-right-color: oklch(0.18 0.01 250);
+  }
+
+  .y2k .y2k-chrome-text {
+    background: linear-gradient(
+      180deg,
+      oklch(0.95 0.03 195) 0%,
+      oklch(0.55 0.02 220) 40%,
+      oklch(0.98 0.02 195) 50%,
+      oklch(0.6 0.02 220) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    filter: drop-shadow(0 0 8px oklch(0.78 0.18 195 / 0.4));
+  }
+
+  .y2k .y2k-neon-text {
+    color: oklch(0.82 0.2 195);
+    text-shadow:
+      0 0 4px oklch(0.78 0.18 195 / 0.8),
+      0 0 12px oklch(0.78 0.18 195 / 0.5),
+      0 0 30px oklch(0.78 0.18 195 / 0.3),
+      0 0 50px oklch(0.78 0.18 195 / 0.1);
+  }
+
+  .y2k .y2k-neon-text-magenta {
+    color: oklch(0.75 0.25 330);
+    text-shadow:
+      0 0 4px oklch(0.65 0.25 330 / 0.8),
+      0 0 12px oklch(0.65 0.25 330 / 0.5),
+      0 0 30px oklch(0.65 0.25 330 / 0.3);
+  }
+
+  .y2k .y2k-neon-text-green {
+    color: oklch(0.8 0.25 145);
+    text-shadow:
+      0 0 4px oklch(0.75 0.22 145 / 0.8),
+      0 0 12px oklch(0.75 0.22 145 / 0.5),
+      0 0 30px oklch(0.75 0.22 145 / 0.3);
+  }
+
+  .y2k .y2k-status-bar {
+    height: 2px;
+    background: linear-gradient(
+      90deg,
+      oklch(0.78 0.18 195),
+      oklch(0.65 0.25 330),
+      oklch(0.75 0.22 145)
+    );
+    background-size: 200% 100%;
+    animation: y2k-gradient-shift 4s ease-in-out infinite;
+    box-shadow: 0 0 12px oklch(0.78 0.18 195 / 0.5);
+  }
+
+  .y2k .y2k-animated-border {
+    position: relative;
+    overflow: hidden;
+  }
+  .y2k .y2k-animated-border::before {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    z-index: -1;
+    border-radius: inherit;
+    background: linear-gradient(
+      45deg,
+      oklch(0.78 0.18 195),
+      oklch(0.65 0.25 330),
+      oklch(0.75 0.22 145),
+      oklch(0.78 0.18 195)
+    );
+    background-size: 300% 300%;
+    animation: y2k-gradient-shift 4s ease infinite;
+    opacity: 0.5;
+  }
+  .y2k .y2k-animated-border::after {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    z-index: -1;
+    border-radius: inherit;
+    background: var(--card);
+  }
+
+  .y2k .y2k-neon-underline {
+    position: relative;
+  }
+  .y2k .y2k-neon-underline::after {
+    content: "";
+    position: absolute;
+    bottom: -4px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(
+      90deg,
+      oklch(0.78 0.18 195),
+      oklch(0.65 0.25 330)
+    );
+    box-shadow: 0 0 8px oklch(0.78 0.18 195 / 0.5);
+    border-radius: 1px;
+  }
+
+  .y2k .y2k-flicker {
+    animation: y2k-flicker 8s ease-in-out infinite;
+  }
+
+  .y2k .y2k-hue-shift {
+    animation: y2k-hue-rotate 12s linear infinite;
+  }
+
   /* Reduced motion support */
   @media (prefers-reduced-motion: reduce) {
     .animate-fade-in-up,
@@ -1206,7 +1654,9 @@
     .animate-progress-ring,
     .animate-spin-slow,
     .animate-pulse-glow,
-    .animate-shimmer {
+    .animate-shimmer,
+    .y2k-border-pulse,
+    .y2k-hue-shift {
       animation: none;
       opacity: 1;
       transform: none;

--- a/savepoint-app/shared/globals.css
+++ b/savepoint-app/shared/globals.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *, .y2k *));
+@custom-variant dark (&:is(.dark *, .y2k *, .jewel *));
 @custom-variant y2k (&:is(.y2k *));
+@custom-variant jewel (&:is(.jewel *));
 
 :root {
   /* Base colors - clean light theme */
@@ -287,11 +288,9 @@
   --shadow-paper:
     0 2px 12px 0 oklch(0 0 0 / 0.6), 0 0 8px 0 oklch(0.72 0.22 145 / 0.1);
   --shadow-paper-md:
-    0 4px 20px 0 oklch(0 0 0 / 0.65),
-    0 0 16px 0 oklch(0.72 0.22 145 / 0.12);
+    0 4px 20px 0 oklch(0 0 0 / 0.65), 0 0 16px 0 oklch(0.72 0.22 145 / 0.12);
   --shadow-paper-lg:
-    0 8px 40px 0 oklch(0 0 0 / 0.75),
-    0 0 30px 0 oklch(0.72 0.22 145 / 0.15);
+    0 8px 40px 0 oklch(0 0 0 / 0.75), 0 0 30px 0 oklch(0.72 0.22 145 / 0.15);
   /* Y2K-specific tokens — Xbox green */
   --y2k-glow-cyan: oklch(0.72 0.22 145);
   --y2k-glow-magenta: oklch(0.6 0.18 165);
@@ -299,8 +298,7 @@
   --y2k-scanline-opacity: 0.05;
   --y2k-glass-opacity: 0.4;
   --y2k-border-glow:
-    0 0 10px oklch(0.72 0.22 145 / 0.45),
-    0 0 3px oklch(0.72 0.22 145 / 0.7),
+    0 0 10px oklch(0.72 0.22 145 / 0.45), 0 0 3px oklch(0.72 0.22 145 / 0.7),
     inset 0 0 6px oklch(0.72 0.22 145 / 0.1);
   --radius: 0.125rem;
   /* Status colors */
@@ -313,6 +311,102 @@
   --status-playing: oklch(0.72 0.22 145);
   --status-playing-foreground: oklch(0.08 0.02 145);
   --status-played: oklch(0.65 0.18 165);
+  --status-played-foreground: oklch(0.08 0.02 165);
+}
+
+.jewel {
+  /* Jewel — synthesized theme: PS2 indigo void + Xbox green emission + GC pearl chrome */
+
+  /* Base colors — PS2 indigo-black void */
+  --jewel-core: oklch(0.72 0.22 145);
+  --jewel-core-bright: oklch(0.82 0.28 145);
+  --jewel-void: oklch(0.1 0.035 270);
+  --jewel-void-raised: oklch(0.14 0.035 265);
+  --jewel-pearl: oklch(0.96 0.015 85);
+  --jewel-pearl-dim: oklch(0.72 0.02 85);
+  --jewel-spark: oklch(0.68 0.25 340);
+
+  /* Mapped to shared design tokens so existing components inherit */
+  --background: var(--jewel-void);
+  --foreground: var(--jewel-pearl);
+  --card: var(--jewel-void-raised);
+  --card-foreground: var(--jewel-pearl);
+  --popover: oklch(0.16 0.04 268);
+  --popover-foreground: var(--jewel-pearl);
+  --primary: var(--jewel-core);
+  --primary-foreground: oklch(0.08 0.02 145);
+  --secondary: oklch(0.16 0.035 268);
+  --secondary-foreground: var(--jewel-pearl);
+  --muted: oklch(0.15 0.035 268);
+  --muted-foreground: var(--jewel-pearl-dim);
+  --accent: oklch(0.18 0.045 268);
+  --accent-foreground: var(--jewel-pearl);
+  --destructive: oklch(0.6 0.22 25);
+  --destructive-foreground: oklch(0.99 0 0);
+  --success: var(--jewel-core-bright);
+  --success-foreground: oklch(0.08 0.02 145);
+  --warning: oklch(0.78 0.16 75);
+  --warning-foreground: oklch(0.12 0.02 75);
+  --info: oklch(0.65 0.15 240);
+  --info-foreground: oklch(0.99 0 0);
+  --border: oklch(0.22 0.04 268);
+  --input: oklch(0.14 0.035 265);
+  --ring: var(--jewel-core);
+
+  /* Chart */
+  --chart-1: var(--jewel-core);
+  --chart-2: var(--jewel-core-bright);
+  --chart-3: var(--jewel-pearl);
+  --chart-4: oklch(0.6 0.15 240);
+  --chart-5: var(--jewel-spark);
+
+  /* Sidebar */
+  --sidebar: oklch(0.08 0.03 270);
+  --sidebar-foreground: var(--jewel-pearl);
+  --sidebar-primary: var(--jewel-core);
+  --sidebar-primary-foreground: oklch(0.08 0.02 145);
+  --sidebar-accent: oklch(0.14 0.04 268);
+  --sidebar-accent-foreground: var(--jewel-pearl);
+  --sidebar-border: oklch(0.2 0.04 268);
+  --sidebar-ring: var(--jewel-core);
+
+  /* Shadows — green bloom over indigo */
+  --shadow-paper-sm:
+    0 1px 3px 0 oklch(0 0 0 / 0.5), 0 0 4px 0 oklch(0.72 0.22 145 / 0.08);
+  --shadow-paper:
+    0 2px 12px 0 oklch(0 0 0 / 0.6), 0 0 10px 0 oklch(0.72 0.22 145 / 0.12);
+  --shadow-paper-md:
+    0 4px 20px 0 oklch(0 0 0 / 0.65), 0 0 18px 0 oklch(0.72 0.22 145 / 0.14);
+  --shadow-paper-lg:
+    0 8px 40px 0 oklch(0 0 0 / 0.75), 0 0 32px 0 oklch(0.72 0.22 145 / 0.16);
+
+  /* Jewel-specific tokens */
+  --jewel-chrome-edge: linear-gradient(
+    135deg,
+    oklch(0.96 0.015 85 / 0.7) 0%,
+    oklch(0.55 0.03 220 / 0.3) 35%,
+    oklch(0.18 0.04 268 / 0.6) 100%
+  );
+  --jewel-glass-fill: oklch(0.14 0.035 265 / 0.55);
+  --jewel-glass-tint: oklch(0.72 0.22 145 / 0.04);
+  --jewel-glass-blur: blur(16px) saturate(1.4);
+  --jewel-neon-bloom:
+    0 0 2px oklch(0.72 0.22 145 / 0.9), 0 0 10px oklch(0.72 0.22 145 / 0.5),
+    0 0 30px oklch(0.72 0.22 145 / 0.2);
+  --jewel-scanline-opacity: 0.04;
+
+  --radius: 0.375rem;
+
+  /* Status colors */
+  --status-wishlist: oklch(0.65 0.15 270);
+  --status-wishlist-foreground: oklch(0.99 0 0);
+  --status-shelf: oklch(0.78 0.14 85);
+  --status-shelf-foreground: oklch(0.12 0.01 85);
+  --status-upNext: oklch(0.78 0.16 75);
+  --status-upNext-foreground: oklch(0.12 0.01 75);
+  --status-playing: var(--jewel-core);
+  --status-playing-foreground: oklch(0.08 0.02 145);
+  --status-played: oklch(0.72 0.18 165);
   --status-played-foreground: oklch(0.08 0.02 165);
 }
 
@@ -569,6 +663,95 @@
   }
 }
 
+/* Jewel motion grammar — four named transitions */
+
+@keyframes jewel-unfold {
+  0% {
+    opacity: 0;
+    transform: perspective(800px) rotateX(-30deg) scale(0.85);
+    filter: blur(8px);
+  }
+  60% {
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: perspective(800px) rotateX(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes jewel-rise {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes jewel-sweep {
+  0% {
+    opacity: 0;
+    transform: translateX(-16px) skewX(-4deg);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) skewX(0);
+  }
+}
+
+@keyframes jewel-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow:
+      0 0 2px oklch(0.72 0.22 145 / 0.6),
+      0 0 8px oklch(0.72 0.22 145 / 0.25),
+      0 0 24px oklch(0.72 0.22 145 / 0.12);
+  }
+  50% {
+    transform: scale(1.008);
+    box-shadow:
+      0 0 3px oklch(0.72 0.22 145 / 0.85),
+      0 0 14px oklch(0.72 0.22 145 / 0.4),
+      0 0 36px oklch(0.72 0.22 145 / 0.18);
+  }
+}
+
+@keyframes jewel-breathe-subtle {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes jewel-chrome-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@keyframes jewel-tower-rise {
+  0% {
+    height: 0%;
+    opacity: 0;
+  }
+  100% {
+    height: var(--tower-h, 0%);
+    opacity: 1;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -647,6 +830,79 @@
         oklch(0.72 0.22 145 / 0.03) 0px,
         transparent 1px,
         transparent 40px
+      );
+  }
+
+  /* Jewel base — ambient environment */
+
+  .jewel ::selection {
+    background: oklch(0.72 0.22 145 / 0.35);
+    color: var(--jewel-pearl);
+  }
+
+  .jewel ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  .jewel ::-webkit-scrollbar-track {
+    background: oklch(0.08 0.03 270);
+  }
+  .jewel ::-webkit-scrollbar-thumb {
+    background: linear-gradient(
+      180deg,
+      oklch(0.72 0.22 145 / 0.5),
+      oklch(0.55 0.18 165 / 0.4)
+    );
+    border-radius: 4px;
+  }
+  .jewel ::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(
+      180deg,
+      oklch(0.82 0.28 145 / 0.8),
+      oklch(0.72 0.22 145 / 0.6)
+    );
+    box-shadow: 0 0 6px oklch(0.72 0.22 145 / 0.4);
+  }
+
+  /* CRT scanlines — subtle, never distracting */
+  .jewel body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      oklch(0 0 0 / var(--jewel-scanline-opacity, 0.04)) 2px,
+      oklch(0 0 0 / var(--jewel-scanline-opacity, 0.04)) 3px
+    );
+  }
+
+  /* Ambient light sources — indigo void with green emission from top-left,
+     pearl warmth from bottom-right. Directional, not uniform. */
+  .jewel body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        ellipse 90% 60% at 15% 0%,
+        oklch(0.72 0.22 145 / 0.14),
+        transparent 55%
+      ),
+      radial-gradient(
+        ellipse 70% 50% at 100% 100%,
+        oklch(0.96 0.015 85 / 0.05),
+        transparent 50%
+      ),
+      radial-gradient(
+        ellipse 50% 40% at 50% 50%,
+        oklch(0.14 0.04 270 / 0.4),
+        transparent 70%
       );
   }
 }
@@ -1738,6 +1994,318 @@
     font-size: 0.85em;
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Jewel Design System — chrome, glass, neon                           */
+  /* Scoped to .jewel theme                                              */
+  /* ------------------------------------------------------------------ */
+
+  /* Material: Chrome — cool pearl→indigo gradient border.
+     Used for outer shells, frames, dividers. Never an accent. */
+  .jewel .jewel-chrome {
+    position: relative;
+    border: 1px solid transparent;
+    background-image:
+      linear-gradient(var(--jewel-void-raised), var(--jewel-void-raised)),
+      var(--jewel-chrome-edge);
+    background-origin: border-box;
+    background-clip: padding-box, border-box;
+  }
+
+  .jewel .jewel-chrome-thin {
+    border: 1px solid oklch(0.72 0.02 85 / 0.32);
+    box-shadow:
+      inset 0 1px 0 oklch(0.96 0.015 85 / 0.14),
+      inset 0 -1px 0 oklch(0 0 0 / 0.4),
+      inset 1px 0 0 oklch(0.96 0.015 85 / 0.06);
+  }
+
+  /* Material: Glass — translucent panel with backdrop blur, green inner tint.
+     Used for cards, panels, modals. Never hard-edged. */
+  .jewel .jewel-glass {
+    background:
+      linear-gradient(135deg, var(--jewel-glass-tint) 0%, transparent 40%),
+      var(--jewel-glass-fill);
+    backdrop-filter: var(--jewel-glass-blur);
+    -webkit-backdrop-filter: var(--jewel-glass-blur);
+    border: 1px solid oklch(0.72 0.22 145 / 0.14);
+    box-shadow:
+      inset 0 1px 0 oklch(0.96 0.015 85 / 0.06),
+      inset 0 0 24px oklch(0.72 0.22 145 / 0.04),
+      0 4px 20px oklch(0 0 0 / 0.5);
+  }
+
+  .jewel .jewel-glass-strong {
+    background:
+      linear-gradient(135deg, oklch(0.72 0.22 145 / 0.06) 0%, transparent 45%),
+      oklch(0.12 0.035 268 / 0.75);
+    backdrop-filter: blur(24px) saturate(1.6);
+    -webkit-backdrop-filter: blur(24px) saturate(1.6);
+    border: 1px solid oklch(0.72 0.22 145 / 0.22);
+    box-shadow:
+      inset 0 1px 0 oklch(0.96 0.015 85 / 0.08),
+      0 8px 32px oklch(0 0 0 / 0.6);
+  }
+
+  /* Material: Neon — point-source emission, 3-layer falloff.
+     Always anchored to a direction (top-left by default). */
+  .jewel .jewel-neon {
+    box-shadow: var(--jewel-neon-bloom);
+  }
+
+  .jewel .jewel-neon-text {
+    color: var(--jewel-core-bright);
+    text-shadow:
+      0 0 4px oklch(0.72 0.22 145 / 0.9),
+      0 0 12px oklch(0.72 0.22 145 / 0.5),
+      0 0 30px oklch(0.72 0.22 145 / 0.2);
+  }
+
+  /* Top-left point-source emission — implies a light bulb off-canvas */
+  .jewel .jewel-neon-bloom {
+    position: relative;
+    isolation: isolate;
+  }
+  .jewel .jewel-neon-bloom::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background: radial-gradient(
+      circle at 15% 15%,
+      oklch(0.72 0.22 145 / 0.25) 0%,
+      oklch(0.72 0.22 145 / 0.08) 25%,
+      transparent 60%
+    );
+    pointer-events: none;
+  }
+
+  /* Hover: rise + bloom, ceremonially */
+  .jewel .jewel-hover-rise {
+    transition:
+      transform 320ms cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 320ms cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 320ms ease-out;
+    will-change: transform;
+  }
+  .jewel .group:hover .jewel-hover-rise,
+  .jewel .jewel-hover-rise:hover {
+    transform: translateY(-5px) scale(1.015);
+    box-shadow:
+      0 0 3px oklch(0.82 0.28 145 / 0.9),
+      0 0 20px oklch(0.72 0.22 145 / 0.55),
+      0 0 56px oklch(0.72 0.22 145 / 0.22),
+      0 16px 40px oklch(0 0 0 / 0.6);
+    border-color: oklch(0.82 0.28 145 / 0.65);
+  }
+
+  /* Motion grammar — four named transitions */
+  .jewel .jewel-unfold {
+    animation: jewel-unfold 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .jewel .jewel-rise {
+    animation: jewel-rise 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .jewel .jewel-sweep {
+    animation: jewel-sweep 300ms cubic-bezier(0.33, 1, 0.68, 1) both;
+  }
+  .jewel .jewel-breathe {
+    animation: jewel-breathe 6s ease-in-out infinite;
+  }
+  .jewel .jewel-breathe-slow {
+    animation: jewel-breathe 8s ease-in-out infinite;
+  }
+
+  /* Typography roles */
+  .jewel .jewel-display {
+    font-family: "Geist", system-ui, sans-serif;
+    font-weight: 300;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .jewel .jewel-meta {
+    font-family: "Geist Mono", "DM Mono", monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--jewel-pearl-dim);
+  }
+
+  .jewel .jewel-meta-tilt {
+    font-family: "Geist Mono", "DM Mono", monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--jewel-pearl-dim);
+    transform: skewX(-6deg);
+    display: inline-block;
+  }
+
+  /* Ceremonial: magenta-spark — rare, allowlisted uses only */
+  .jewel .jewel-spark {
+    color: var(--jewel-spark);
+    text-shadow:
+      0 0 4px oklch(0.68 0.25 340 / 0.8),
+      0 0 14px oklch(0.68 0.25 340 / 0.4);
+  }
+  .jewel .jewel-spark-bloom {
+    box-shadow:
+      0 0 3px oklch(0.68 0.25 340 / 0.9),
+      0 0 12px oklch(0.68 0.25 340 / 0.5),
+      0 0 32px oklch(0.68 0.25 340 / 0.2);
+    border-color: oklch(0.68 0.25 340 / 0.5);
+  }
+
+  /* PS2 boot-tower stat visualization — vertical glass columns rising by count */
+  .jewel .jewel-tower {
+    position: relative;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background: linear-gradient(
+      180deg,
+      oklch(0.72 0.22 145 / 0.04),
+      oklch(0.72 0.22 145 / 0.02)
+    );
+    border: 1px solid oklch(0.72 0.22 145 / 0.15);
+    border-radius: 2px;
+    overflow: hidden;
+    box-shadow: inset 0 0 12px oklch(0 0 0 / 0.4);
+  }
+
+  .jewel .jewel-tower-fill {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: var(--tower-h, 0%);
+    background-image: linear-gradient(
+      180deg,
+      oklch(0.96 0.015 85 / 0.25) 0%,
+      transparent 30%
+    );
+    box-shadow:
+      inset 0 1px 0 oklch(0.96 0.015 85 / 0.4),
+      0 0 16px oklch(0.72 0.22 145 / 0.5),
+      0 -2px 12px currentColor;
+    animation: jewel-tower-rise 900ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .jewel .jewel-tower-count {
+    position: absolute;
+    top: 4px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-family: "Geist Mono", "DM Mono", monospace;
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    color: var(--jewel-pearl);
+    text-shadow: 0 0 4px oklch(0 0 0 / 0.8);
+    z-index: 2;
+  }
+
+  .jewel .jewel-dot {
+    box-shadow:
+      0 0 4px currentColor,
+      0 0 10px oklch(from currentColor l c h / 0.4);
+  }
+
+  /* Horizontal segmented progress bar with neon sheen */
+  .jewel .jewel-progress-glow {
+    background: oklch(0.08 0.03 270);
+    border: 1px solid oklch(0.72 0.22 145 / 0.2);
+    box-shadow:
+      inset 0 1px 2px oklch(0 0 0 / 0.6),
+      0 0 12px oklch(0.72 0.22 145 / 0.25);
+  }
+
+  /* Header logo emission */
+  .jewel .jewel-logo-glow {
+    filter: drop-shadow(0 0 6px oklch(0.72 0.22 145 / 0.7))
+      drop-shadow(0 0 14px oklch(0.72 0.22 145 / 0.3));
+  }
+
+  /* Nav link states */
+  .jewel .jewel-nav-inactive {
+    font-family: "Geist Mono", "DM Mono", monospace;
+    font-weight: 400;
+  }
+
+  .jewel .jewel-nav-active {
+    position: relative;
+    font-family: "Geist Mono", "DM Mono", monospace;
+    font-weight: 600;
+    color: var(--jewel-core-bright);
+    text-shadow:
+      0 0 4px oklch(0.72 0.22 145 / 0.8),
+      0 0 12px oklch(0.72 0.22 145 / 0.4);
+  }
+  .jewel .jewel-nav-active::after {
+    content: "";
+    position: absolute;
+    bottom: -6px;
+    left: -2px;
+    right: -2px;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      oklch(0.82 0.28 145 / 0.9) 20%,
+      oklch(0.82 0.28 145) 50%,
+      oklch(0.82 0.28 145 / 0.9) 80%,
+      transparent
+    );
+    box-shadow: 0 0 6px oklch(0.72 0.22 145 / 0.6);
+  }
+
+  /* Badge treatment — applied to every Badge under .jewel.
+     Gives glass-backed body + neon glow that tints with the variant color. */
+  .jewel .jewel-badge {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    backdrop-filter: blur(8px) saturate(1.3);
+    -webkit-backdrop-filter: blur(8px) saturate(1.3);
+    box-shadow:
+      0 0 2px currentColor,
+      0 0 10px oklch(from currentColor l c h / 0.35),
+      inset 0 1px 0 oklch(0.96 0.015 85 / 0.18),
+      inset 0 -1px 0 oklch(0 0 0 / 0.3);
+    border-color: oklch(from currentColor l c h / 0.4);
+    text-shadow: 0 0 6px oklch(from currentColor l c h / 0.5);
+  }
+
+  /* Corner brackets — subtle tactical framing for hero surfaces */
+  .jewel .jewel-corners {
+    position: relative;
+  }
+  .jewel .jewel-corners::before,
+  .jewel .jewel-corners::after {
+    content: "";
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    pointer-events: none;
+    z-index: 2;
+  }
+  .jewel .jewel-corners::before {
+    top: 4px;
+    left: 4px;
+    border-top: 1px solid oklch(0.72 0.22 145 / 0.7);
+    border-left: 1px solid oklch(0.72 0.22 145 / 0.7);
+    filter: drop-shadow(0 0 3px oklch(0.72 0.22 145 / 0.5));
+  }
+  .jewel .jewel-corners::after {
+    bottom: 4px;
+    right: 4px;
+    border-bottom: 1px solid oklch(0.72 0.22 145 / 0.5);
+    border-right: 1px solid oklch(0.72 0.22 145 / 0.5);
+    filter: drop-shadow(0 0 3px oklch(0.72 0.22 145 / 0.3));
+  }
+
   /* Reduced motion support */
   @media (prefers-reduced-motion: reduce) {
     .animate-fade-in-up,
@@ -1749,7 +2317,12 @@
     .animate-pulse-glow,
     .animate-shimmer,
     .y2k-border-pulse,
-    .y2k-hue-shift {
+    .y2k-hue-shift,
+    .jewel-unfold,
+    .jewel-rise,
+    .jewel-sweep,
+    .jewel-breathe,
+    .jewel-breathe-slow {
       animation: none;
       opacity: 1;
       transform: none;

--- a/savepoint-app/shared/providers/providers.tsx
+++ b/savepoint-app/shared/providers/providers.tsx
@@ -38,7 +38,10 @@ export function Providers({
   const queryClient = useState(() => getQueryClient())[0];
 
   return (
-    <NextThemesProvider {...props} themes={["light", "dark", "y2k", "system"]}>
+    <NextThemesProvider
+      {...props}
+      themes={["light", "dark", "y2k", "jewel", "system"]}
+    >
       <SessionProvider refetchInterval={5 * 60} refetchOnWindowFocus={false}>
         <QueryClientProvider client={queryClient}>
           <NextTopLoader />

--- a/savepoint-app/shared/providers/providers.tsx
+++ b/savepoint-app/shared/providers/providers.tsx
@@ -38,7 +38,7 @@ export function Providers({
   const queryClient = useState(() => getQueryClient())[0];
 
   return (
-    <NextThemesProvider {...props}>
+    <NextThemesProvider {...props} themes={["light", "dark", "y2k", "system"]}>
       <SessionProvider refetchInterval={5 * 60} refetchOnWindowFocus={false}>
         <QueryClientProvider client={queryClient}>
           <NextTopLoader />

--- a/savepoint-app/widgets/header/ui/header.tsx
+++ b/savepoint-app/widgets/header/ui/header.tsx
@@ -27,7 +27,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   if (isAuthorised) {
     return (
       <>
-        <header className="bg-background/80 border-border/10 py-lg md:py-xl sticky top-0 z-50 border-b backdrop-blur-xl">
+        <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.78_0.18_195/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
           <div className="container mx-auto flex items-center justify-between">
             <h1 className="heading-md md:heading-xl tracking-tight">
               <Link
@@ -41,35 +41,37 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
                   height={40}
                   className="h-8 w-8 md:h-10 md:w-10"
                 />
-                <span>SavePoint</span>
+                <span className="y2k-chrome-text y2k:tracking-wider">
+                  SavePoint
+                </span>
               </Link>
             </h1>
             <nav className="gap-lg md:gap-2xl flex items-center">
               <div className="gap-2xl hidden items-center md:flex">
                 <Link
                   href="/dashboard"
-                  className={`body-sm transition-colors ${isActive("/dashboard") ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground font-medium"}`}
+                  className={`body-sm transition-all ${isActive("/dashboard") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
                   aria-current={isActive("/dashboard") ? "page" : undefined}
                 >
                   Dashboard
                 </Link>
                 <Link
                   href="/library"
-                  className={`body-sm transition-colors ${isActive("/library") ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground font-medium"}`}
+                  className={`body-sm transition-all ${isActive("/library") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
                   aria-current={isActive("/library") ? "page" : undefined}
                 >
                   Library
                 </Link>
                 <Link
                   href="/journal"
-                  className={`body-sm transition-colors ${isActive("/journal") ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground font-medium"}`}
+                  className={`body-sm transition-all ${isActive("/journal") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
                   aria-current={isActive("/journal") ? "page" : undefined}
                 >
                   Journal
                 </Link>
                 <Link
                   href="/profile"
-                  className={`body-sm transition-colors ${isActive("/profile") ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground font-medium"}`}
+                  className={`body-sm transition-all ${isActive("/profile") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
                   aria-current={isActive("/profile") ? "page" : undefined}
                 >
                   Profile
@@ -97,7 +99,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   }
   return (
     <>
-      <header className="bg-background/80 border-border/10 py-lg md:py-xl sticky top-0 z-50 border-b backdrop-blur-xl">
+      <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.78_0.18_195/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
         <div className="container mx-auto flex items-center justify-between">
           <h1 className="heading-md md:heading-xl tracking-tight">
             <Link

--- a/savepoint-app/widgets/header/ui/header.tsx
+++ b/savepoint-app/widgets/header/ui/header.tsx
@@ -13,6 +13,13 @@ import {
 import { ThemeToggle } from "@/shared/components/theme-toggle";
 import { Button } from "@/shared/components/ui/button";
 
+const NAV_LINKS = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/library", label: "Library" },
+  { href: "/journal", label: "Journal" },
+  { href: "/profile", label: "Profile" },
+] as const;
+
 export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   const { isOpen, open, close } = useCommandPaletteContext();
   const pathname = usePathname();
@@ -27,7 +34,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   if (isAuthorised) {
     return (
       <>
-        <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.72_0.22_145/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
+        <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.72_0.22_145/0.15)] jewel-glass-strong jewel:border-b-0 jewel:shadow-[0_1px_0_oklch(0.72_0.22_145/0.25),0_8px_32px_oklch(0_0_0/0.5)] sticky top-0 z-50 border-b backdrop-blur-2xl">
           <div className="container mx-auto flex items-center justify-between">
             <h1 className="heading-md md:heading-xl tracking-tight">
               <Link
@@ -39,43 +46,32 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
                   alt="SavePoint Logo"
                   width={40}
                   height={40}
-                  className="y2k-logo-glow h-8 w-8 md:h-10 md:w-10"
+                  className="y2k-logo-glow jewel-logo-glow h-8 w-8 md:h-10 md:w-10"
                 />
-                <span className="y2k-chrome-text y2k:tracking-wider">
+                <span className="y2k-chrome-text y2k:tracking-wider jewel-display jewel:tracking-[0.14em]">
                   SavePoint
                 </span>
               </Link>
             </h1>
             <nav className="gap-lg md:gap-2xl flex items-center">
               <div className="gap-2xl hidden items-center md:flex">
-                <Link
-                  href="/dashboard"
-                  className={`body-sm transition-all ${isActive("/dashboard") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
-                  aria-current={isActive("/dashboard") ? "page" : undefined}
-                >
-                  Dashboard
-                </Link>
-                <Link
-                  href="/library"
-                  className={`body-sm transition-all ${isActive("/library") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
-                  aria-current={isActive("/library") ? "page" : undefined}
-                >
-                  Library
-                </Link>
-                <Link
-                  href="/journal"
-                  className={`body-sm transition-all ${isActive("/journal") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
-                  aria-current={isActive("/journal") ? "page" : undefined}
-                >
-                  Journal
-                </Link>
-                <Link
-                  href="/profile"
-                  className={`body-sm transition-all ${isActive("/profile") ? "text-foreground y2k-neon-text y2k-neon-underline font-semibold" : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 font-medium"}`}
-                  aria-current={isActive("/profile") ? "page" : undefined}
-                >
-                  Profile
-                </Link>
+                {NAV_LINKS.map(({ href, label }) => {
+                  const active = isActive(href);
+                  return (
+                    <Link
+                      key={href}
+                      href={href}
+                      className={`body-sm transition-all jewel:uppercase jewel:tracking-[0.14em] jewel:text-[0.72rem] ${
+                        active
+                          ? "text-foreground y2k-neon-text y2k-neon-underline jewel-nav-active font-semibold"
+                          : "text-muted-foreground hover:text-foreground y2k:hover:text-primary/70 jewel:hover:text-primary jewel-nav-inactive font-medium"
+                      }`}
+                      aria-current={active ? "page" : undefined}
+                    >
+                      {label}
+                    </Link>
+                  );
+                })}
               </div>
               <Button
                 variant="ghost"

--- a/savepoint-app/widgets/header/ui/header.tsx
+++ b/savepoint-app/widgets/header/ui/header.tsx
@@ -27,7 +27,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   if (isAuthorised) {
     return (
       <>
-        <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.78_0.18_195/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
+        <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.72_0.22_145/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
           <div className="container mx-auto flex items-center justify-between">
             <h1 className="heading-md md:heading-xl tracking-tight">
               <Link
@@ -39,7 +39,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
                   alt="SavePoint Logo"
                   width={40}
                   height={40}
-                  className="h-8 w-8 md:h-10 md:w-10"
+                  className="y2k-logo-glow h-8 w-8 md:h-10 md:w-10"
                 />
                 <span className="y2k-chrome-text y2k:tracking-wider">
                   SavePoint
@@ -99,7 +99,7 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
   }
   return (
     <>
-      <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.78_0.18_195/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
+      <header className="bg-background/60 border-border/10 py-lg md:py-xl y2k-glass-strong y2k:border-b-0 y2k:shadow-[0_1px_0_oklch(0.72_0.22_145/0.15)] sticky top-0 z-50 border-b backdrop-blur-2xl">
         <div className="container mx-auto flex items-center justify-between">
           <h1 className="heading-md md:heading-xl tracking-tight">
             <Link
@@ -111,9 +111,11 @@ export function Header({ isAuthorised }: { isAuthorised: boolean }) {
                 alt="SavePoint Logo"
                 width={40}
                 height={40}
-                className="h-8 w-8 md:h-10 md:w-10"
+                className="y2k-logo-glow h-8 w-8 md:h-10 md:w-10"
               />
-              <span>SavePoint</span>
+              <span className="y2k-chrome-text y2k:tracking-wider">
+                SavePoint
+              </span>
             </Link>
           </h1>
           <nav className="gap-lg md:gap-2xl flex items-center">

--- a/savepoint-app/widgets/header/ui/mobile-nav.tsx
+++ b/savepoint-app/widgets/header/ui/mobile-nav.tsx
@@ -58,6 +58,7 @@ export function MobileNav() {
         "fixed inset-x-0 bottom-0 z-50 md:hidden",
         "bg-background/95 backdrop-blur-md",
         "border-border border-t",
+        "y2k:bg-background/60 y2k:border-t-0 y2k:shadow-[0_-1px_0_oklch(0.78_0.18_195/0.2),0_-4px_20px_oklch(0.78_0.18_195/0.05)] y2k:backdrop-blur-2xl",
         "pb-[env(safe-area-inset-bottom)]"
       )}
     >

--- a/savepoint-app/widgets/header/ui/mobile-nav.tsx
+++ b/savepoint-app/widgets/header/ui/mobile-nav.tsx
@@ -58,7 +58,7 @@ export function MobileNav() {
         "fixed inset-x-0 bottom-0 z-50 md:hidden",
         "bg-background/95 backdrop-blur-md",
         "border-border border-t",
-        "y2k:bg-background/60 y2k:border-t-0 y2k:shadow-[0_-1px_0_oklch(0.78_0.18_195/0.2),0_-4px_20px_oklch(0.78_0.18_195/0.05)] y2k:backdrop-blur-2xl",
+        "y2k:bg-background/60 y2k:border-t-0 y2k:shadow-[0_-1px_0_oklch(0.72_0.22_145/0.2),0_-4px_20px_oklch(0.72_0.22_145/0.05)] y2k:backdrop-blur-2xl",
         "pb-[env(safe-area-inset-bottom)]"
       )}
     >


### PR DESCRIPTION
## Summary

- Adds **Jewel**, a new selectable theme distilling the shared DNA of PS2, GameCube, and original Xbox into one cohesive visual language: chrome frames, glass reveals, neon emits, on an indigo void.
- Scales the treatment across header, dashboard, library, game detail, and profile via Card/Badge primitive inheritance plus targeted surface work.
- Full design spec at `context/spec/jewel-theme/spec.md` — principles, tokens, motion grammar, magenta-spark allowlist, surface map.

## What is in

**Design system**
- Palette: `--jewel-core` (Xbox radioactive green) + `--jewel-void` (PS2 indigo) + `--jewel-pearl` (GameCube warm gloss) + ceremonial `--jewel-spark` (magenta, allowlisted)
- Four named motions: `unfold` (500ms), `rise` (400ms), `sweep` (300ms), `breathe` (4-8s idle)
- Seven principles govern every surface — weight, directional light, material segregation, idle motion, transition ceremony, optional sound, optimistic mood
- All custom classes self-scope via `.jewel .jewel-*` — light and dark themes fully insulated
- `prefers-reduced-motion` disables all idle and transition animation

**Scaled surfaces**
- Theme toggle exposes `Jewel` alongside `light` / `dark` / `y2k` / `system`
- `Card` + `Badge` primitives inherit chrome + glass + neon automatically, cascading to most card surfaces in the app
- **Header**: glass-strong bar, logo glow, mono nav links with active neon underline
- **Dashboard stats**: PS2 boot-tower visualization — vertical glass columns rise from zero to the count value and breathe on idle, with tactical `// LIBRARY` header and mono meta legend
- **Library grid card**: chrome-thin edge + glass fill + top-left point-source neon bloom + corner brackets + tactical `// SLUG 001` meta strip + uppercase display title + ceremonial hover rise
- **Game detail page**: `// GAME.DETAIL ———— THE-WITCHER-` header rule, uppercase tracked title, `// GENRES` / `// PLATFORMS` mono labels, corner-bracketed cover sidebar
- **Profile page**: `// PROFILE.VIEW` + `// RECENT.PLAYS` tactical rules, chrome-framed glowing avatar, PS2-style status breakdown with neon dots and big jewel-neon count numbers, bespoke recent-play cards upgraded to full library-card treatment

## Test plan

- [ ] Flip theme to **Jewel** and walk through each page: /dashboard, /library, /games/[slug], /profile, /journal
- [ ] Verify **Light** and **Dark** themes are completely unaffected
- [ ] Verify **Y2K** legacy theme still works in parallel
- [ ] Test hover ceremonies on library cards and profile recent-play cards (rise + bloom + border brighten)
- [ ] Verify dashboard PS2 boot-tower animation on mount
- [ ] Verify idle breathing is subtle and not distracting
- [ ] Confirm `prefers-reduced-motion` disables breathe / rise / unfold / sweep
- [ ] Check mobile breakpoints for library card meta strip wrap
- [ ] Confirm no magenta-spark leaks outside the allowlist (currently zero usages — reserved for future achievement ceremony)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Jewel" — an opt-in Y2K-inspired visual theme with tokens, materials, motion grammar, and scoped UI treatments.
  * Replaced binary theme toggle with a multi-theme dropdown (light, dark, Y2K, Jewel, system).
  * Added new themed animations (unfold/rise/sweep/breathe) and ambient effects.

* **Bug Fixes**
  * Fixed search filter sync when URL search parameter is absent.

* **Style**
  * Applied Jewel/Y2K styling across dashboard, game details, library, profile, header, mobile nav, cards, badges, buttons, and activity feed.

* **Documentation**
  * Added a Jewel theme specification and migration/rollout plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->