### PR TITLE
fix(tanstack): generate Prisma client during build (fixes Vercel build)

### DIFF
--- a/.github/workflows/pr-checks-tanstack.yml
+++ b/.github/workflows/pr-checks-tanstack.yml
@@ -79,6 +79,14 @@ jobs:
       # — e.g. a public barrel re-exporting a server-only `.server.ts` value into
       # the client bundle, which trips tanstack-start's import-protection plugin.
       - name: Build (production bundle)
+        env:
+          # `build` now runs `prisma generate && vite build` so a fresh checkout
+          # (e.g. Vercel) generates the client into the source tree before
+          # bundling. `prisma.config.ts` requires a DB URL at config-load even
+          # for generate (which never connects) — placeholder, mirroring the
+          # dedicated generate step above.
+          POSTGRES_PRISMA_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+          POSTGRES_URL_NON_POOLING: postgresql://placeholder:placeholder@localhost:5432/placeholder
         run: pnpm --filter savepoint-tanstack build
 
       # Runs the merged unit + integration projects under v8 coverage and

--- a/savepoint-tanstack/docs/vercel-deployment.md
+++ b/savepoint-tanstack/docs/vercel-deployment.md
@@ -7,7 +7,17 @@ spec-021 cutover. Read this with [`../CLAUDE.md`](../CLAUDE.md) and
 ## How the build produces a deployable artifact
 
 - The app builds with Vite: `pnpm --filter savepoint-tanstack build` (script
-  `build` = `vite build`).
+  `build` = **`prisma generate && vite build`**).
+- **Prisma client is generated as part of the build.** The generator outputs to
+  the source tree (`shared/lib/prisma/`, per `prisma/schema.prisma`
+  `output = "../shared/lib/prisma"`), which is **gitignored** — so a fresh
+  checkout (every Vercel build) has no client until generated. Folding
+  `prisma generate` into `build` guarantees it exists before bundling.
+  `prisma.config.ts` loads `.env` locally and requires
+  `POSTGRES_URL_NON_POOLING` (or `POSTGRES_PRISMA_URL`) at config-load — even
+  though generate never connects — so **that DB URL must be present in the
+  Vercel build environment** (it is, if set for the deploying environment; see
+  Required environment variables).
 - `vite.config.ts` runs `tanstackStart()` **then** `nitro()` (the `nitro/vite`
   plugin from the `nitro` package). Nitro is the agnostic server layer
   TanStack Start v1 deploys through — without it, `vite build` only emits
@@ -86,21 +96,24 @@ to the deployed origin), `AUTH_MIGRATION_CUTOVER_AT`, `AUTH_COGNITO_ID`,
 
 **Runtime:** `NODE_ENV=production`, `LOG_LEVEL` (optional).
 
-`env.ts` validates these at startup; a missing required key fails the build/boot
-fast with a clear message.
+`env.ts` validates these at startup; a missing required key fails the boot fast
+with a clear message. Separately, a missing `POSTGRES_URL_NON_POOLING` /
+`POSTGRES_PRISMA_URL` fails the **build** (the `prisma generate` step's
+`prisma.config.ts` throws) — so ensure those are set for the deploying
+environment, not just at runtime.
 
 ## Verifying a build locally before deploy
 
 ```bash
-docker compose up -d                              # local Postgres on :6432 (only needed at runtime, not for the build)
-pnpm --filter savepoint-tanstack build            # must exit 0
+docker compose up -d                              # local Postgres on :6432 (runtime; build only needs the DB URL in .env, not a live connection)
+pnpm --filter savepoint-tanstack build            # prisma generate (reads .env) + vite build; must exit 0
 test -f savepoint-tanstack/.output/server/index.mjs && echo OK   # Nitro server entry present
 pnpm --filter savepoint-tanstack start            # boots node .output/server/index.mjs
 ```
 
 ## Cutover
 
-Cutover (spec 021, Slice 20) is flipping the production Vercel project's Root
+Cutover (spec 021, Slice 24) is flipping the production Vercel project's Root
 Directory from `savepoint-app` to `savepoint-tanstack` (or repointing the
 domain to this project). Both apps share the same Postgres, Better Auth tables,
 S3 bucket, and IGDB client, so no data migration is required. Roll back by

--- a/savepoint-tanstack/package.json
+++ b/savepoint-tanstack/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 6060",
-    "build": "vite build",
+    "build": "prisma generate && vite build",
     "start": "node --env-file-if-exists=.env .output/server/index.mjs",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",

--- a/savepoint-tanstack/prisma.config.ts
+++ b/savepoint-tanstack/prisma.config.ts
@@ -1,5 +1,15 @@
 import { defineConfig } from "prisma/config";
 
+// Prisma 7's `prisma.config.ts` disables automatic `.env` loading. Load it
+// ourselves so `prisma generate` (run as part of `build`) finds the DB URL
+// from `.env` locally. In CI / Vercel there is no `.env` file — the URL comes
+// from the injected `process.env`, so the missing-file case is ignored.
+try {
+  process.loadEnvFile();
+} catch {
+  // No `.env` present (CI / Vercel) — rely on the ambient process.env.
+}
+
 export default defineConfig({
   schema: "prisma/schema.prisma",
   datasource: {


### PR DESCRIPTION
## Summary

Follow-up to #319. The merged `main` still has a **broken production build** for `savepoint-tanstack/`: `vite build` fails with `UNRESOLVED_IMPORT` for the generated Prisma client (`shared/lib/prisma/client.ts`).

**Root cause:** the Prisma generator outputs into the **source tree** (`shared/lib/prisma/`, gitignored), not `node_modules`. So a fresh checkout (every Vercel build) has no client, and `build: vite build` never generated one. node_modules caching can't supply a source-tree artifact. (CI was green only because `pr-checks-tanstack.yml` runs a dedicated `prisma generate` step before the build.)

## Changes
- **`package.json`**: `build` = `prisma generate && vite build` — every fresh checkout generates the client before bundling.
- **`prisma.config.ts`**: load `.env` (guarded `process.loadEnvFile()`) so `prisma generate` finds the DB URL locally; CI/Vercel use the injected `process.env` (no `.env` file).
- **`pr-checks-tanstack.yml`**: give the build step the placeholder DB URL env (`prisma.config.ts` requires a URL at config-load even though generate never connects) — mirrors the dedicated generate step.
- **`docs/vercel-deployment.md`**: document the build-time `prisma generate` + that the DB URL must be present in the Vercel **build** env (not just runtime).

## Verification
```
rm -rf shared/lib/prisma && pnpm --filter savepoint-tanstack build
# → client regenerated, .output/server/index.mjs produced, exit 0
```
typecheck / lint / format:check all clean.

## Note for Vercel
Set `POSTGRES_URL_NON_POOLING` (or `POSTGRES_PRISMA_URL`) in the Vercel **build** environment, not just runtime — the build's `prisma generate` reads it at config-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vercel deployment documentation with clearer guidance on database environment variable requirements for both build and runtime phases.

* **Chores**
  * Enhanced build process to properly initialize database configuration in CI and cloud deployment environments without requiring local database connectivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NeiruBugz/play-later-v2/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->