### PR TITLE
feat(game-detail): enriched bento game-detail page (spec 023)

### DIFF
--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -44,6 +44,7 @@ _Everything we can ship on our own data + IGDB, with no AWS / external platform 
 - [x] **UX Audit — Round 1** _(Spec 012)_ — library scannability, mobile filters, dashboard hero, onboarding entry, library card redesign, quick add.
 - [x] **UX Audit — Round 2** _(Spec 014)_ — game detail / journal / profile / settings / auth surfaces; navigational connective tissue; Raycast-style command center direction. 12 pinned findings (3 High / 7 Medium / 2 Low).
 - [x] **Unified Design System (Light + Dark)** _(Spec 022)_ — consolidated 5 themes → warm-cream Light + warm-charcoal Dark on one swappable accent (sage, baked in), Space Grotesk headings, crisp 3px radii, layered shadows, new Save Glow logo. Retired-theme users fall back to System. _Supersedes the "Theme Variants & Density Modes" archive note below — the product now ships exactly two themes by design, not Terminal Green._
+- [x] **Game Detail — Enrichment Pass** _(Spec 023)_ — recomposed the tabbed game-detail page into an inline bento dashboard surfacing data the app already had: critic-score ring, screenshot gallery + lightbox, About, Themes & Tags (family-colored platform badges), consolidated "Your Record" (playtime / sessions / rating), in-place status pill (popover desktop / sheet mobile), "Log a session" with optional minutes, you-vs-benchmark Times to Beat with a "Your Pace" fallback, related games, and full graceful degradation. No migration. _Ships independently of and partially ahead of the fuller "Game Detail Redesign" (#4); accent = "you" design rule._
 
 ### In Progress
 
@@ -55,7 +56,7 @@ _Everything we can ship on our own data + IGDB, with no AWS / external platform 
 
 3. [ ] **Public Reflections** — opt-in to make journal entries public; browse community reflections on a game. _Builds on Spec 008 public profiles._
 
-4. [ ] **Game Detail Redesign** — single coordinated pass: hero with blurred cover backdrop, one-click status strip (no modal), personal stats column (playthroughs / your rating / journal count), community stats column, playthrough timeline, reviews feed, franchise / series / expansions / related games. _Consumes Per-Playthrough Logs + Reviews; replaces piecemeal asks (in-page status toggles, enhanced game details, fallback cover rendering)._
+4. [ ] **Game Detail Redesign** — single coordinated pass: hero with blurred cover backdrop, one-click status strip (no modal), personal stats column (playthroughs / your rating / journal count), community stats column, playthrough timeline, reviews feed, franchise / series / expansions / related games. _Consumes Per-Playthrough Logs + Reviews; replaces piecemeal asks (in-page status toggles, enhanced game details, fallback cover rendering)._ **Note (Spec 023):** the enrichment pass already shipped the catalog-side and personal-single-playthrough parts (bento hero + backdrop, in-place status pill, your-record stats, related games, times-to-beat). What remains here is strictly the multi-playthrough/community layer — playthrough timeline, community stats column, reviews feed — which still depends on Per-Playthrough Logs + Reviews._
 
 5. [ ] **Aggregate Game Stats** — community data on game detail: play counts (playing / played / backlog / wishlist), average rating + histogram, average / median completion time, review count. _Depends on Reviews._
 

--- a/context/spec/023-enriched-game-detail/functional-spec.md
+++ b/context/spec/023-enriched-game-detail/functional-spec.md
@@ -1,0 +1,171 @@
+# Functional Specification: Enriched Game Detail Page
+
+- **Roadmap Item:** Game Detail — enrichment pass (surface information the app already has; ships independently of the fuller "Game Detail Redesign", which adds reviews, community stats, and a playthrough timeline)
+- **Status:** Completed
+- **Author:** Nail Badiullin
+
+---
+
+## 1. Overview and Rationale (The "Why")
+
+### Context
+
+A game's detail page is the most data-rich screen in SavePoint, yet today it shows only a small slice of what we know about a game: a short summary, the release year, genres, and platforms. Everything else — the critic score, screenshots, themes, the publisher, and how this game relates to others — is either hidden behind secondary tabs or never shown at all. A patient gamer who opens a game they love sees a page that feels emptier than the game deserves.
+
+At the same time, the things that make SavePoint *personal* — your status, your rating, your time with the game, and your written reflections — are scattered around the page rather than presented as a coherent "your history with this world."
+
+### The problem we're solving
+
+When a patient gamer opens a game's page, they should immediately get a satisfying, complete picture — both of the game itself and of their own relationship to it — without hunting through tabs or feeling like the page is a stub. The page should also act gracefully when a game has very little information available, which is common for older or niche titles, rather than showing broken or empty boxes.
+
+### Desired outcome
+
+A single, richer game detail page that:
+
+- Brings forward the information we already have about a game into one well-organized layout.
+- Gathers the personal layer (your status, rating, time, and journal) into a clear "your record" area, and lets you change your status and add a reflection without leaving the page.
+- Stays calm and tasteful — never cluttered — and adapts cleanly when information is missing, hiding empty areas rather than padding them with placeholders.
+- Works equally well on desktop and on a phone.
+
+### Guiding design principle
+
+One visual rule runs through the whole page: **the accent color always means "you."** Your status, your time, your rating, and your reflections are accented; facts about the game itself (critic score, themes, release info) stay neutral; platform names keep their own recognizable platform colors. This lets a user tell at a glance what is *theirs* versus what is *the catalog's*.
+
+### How we'll measure success
+
+- Users open and stay on game detail pages more, and reach the "add a reflection" action more often from this page.
+- Users change a game's status directly from its detail page rather than going elsewhere.
+- Pages for sparse, little-known games still look intentional and complete, with no empty or broken sections reported.
+
+---
+
+## 2. Functional Requirements (The "What")
+
+The page is organized as a **hero** (top), an optional **screenshot strip**, and a set of **information panels** below. Panels only appear when they have something to show. The following requirements describe each area.
+
+### 2.1 Hero
+
+- **As a** user, **I want** the top of the page to show the game's cover, key facts, my current status, and the critic score at a glance, **so that** I immediately understand both the game and where I stand with it.
+  - **Acceptance Criteria:**
+    - [x] The hero shows the game's cover art. When no cover art is available, a colored placeholder with the game's initials is shown instead (never a broken image).
+    - [x] The hero shows the game's title.
+    - [x] Above the title, a single line shows the release year, the publisher, and the primary genre, separated by small dots. Any of these three that are unknown are simply omitted from the line; if all three are unknown, the line does not appear.
+    - [x] A **critic score** is shown as a circular score indicator with the numeric score. If no critic score is available for the game, the indicator does not appear at all.
+    - [x] A soft, faded backdrop sits behind the hero. When the game has screenshots, the backdrop is drawn from the game's own art. When it has none, the backdrop falls back to a gentle accent-colored wash. The backdrop never obscures the title or controls.
+
+### 2.2 Status control (change status in place)
+
+- **As a** user who has this game in my library, **I want to** change my status for the game directly on its page, **so that** I don't have to open a separate screen to update where I am with it.
+  - **Acceptance Criteria:**
+    - [x] The hero shows a **status pill** displaying my current status (Wishlist, Shelf, Up Next, Playing, or Played), tinted with that status's color and showing its icon.
+    - [x] On desktop, clicking the pill opens a small menu anchored to it, listing all statuses, each with its icon; my current status is checked. Clicking elsewhere closes the menu without changing anything.
+    - [x] On a phone, tapping the pill slides up a sheet from the bottom listing the same statuses; my current status is checked.
+    - [x] Choosing a status updates the pill immediately and closes the menu/sheet. The change is remembered when I return to the page later.
+    - [x] When "Up Next" applies to a game I have already played, it is labeled "Replay" (matching the rest of the app).
+    - [x] If the game is **not yet in my library** (or I am not signed in), the pill is replaced by an **"Add to library"** action; using it adds the game (signed-in users) or prompts me to sign in.
+
+### 2.3 Your Record
+
+- **As a** user, **I want** a single panel that summarizes my history with the game — my time, how many times I've sat down with it, and my rating — with a quick way to log a new session, **so that** my personal relationship with the game is front and center.
+  - **Acceptance Criteria:**
+    - [x] The panel shows my **playtime** for the game, totaled from the time I've recorded across my logged sessions. When I haven't recorded any time, the playtime figure is omitted rather than shown as zero or a dash.
+    - [x] The panel shows a **sessions** count, defined as the number of journal entries I have written for this game.
+    - [x] The panel shows **my rating** as interactive stars. Clicking a star sets my rating; clicking the same level again clears it. When unrated, the stars show a subtle "Rate it" prompt. The chosen rating is remembered.
+    - [x] The panel includes a **"Log a session"** action. Using it opens a quick reflection composer (a dialog on desktop, a bottom sheet on phone) with an **optional "time played" field** and an optional text field for what happened.
+    - [x] Saving from the composer adds a new journal entry for this game; the new entry appears at the top of the Journal panel, the sessions count goes up by one, my total playtime increases by the time I entered (if any), and the composer closes. Saving with both fields left empty still records the session.
+    - [x] Closing or cancelling the composer makes no change.
+
+> Note: "Log a session" records a journal entry. The optional time captured on a session is what feeds my total playtime and the "Your Pace" view; the app does not pull playtime from any other source in this feature.
+
+### 2.4 Times to Beat (with Your Pace fallback)
+
+- **As a** user, **I want** to see how my own time with the game compares to how long the game typically takes, **so that** my progress is given meaning — and when no such comparison exists, to still see my own rhythm rather than an empty box.
+  - **Acceptance Criteria:**
+    - [x] **When the game has community "time to beat" estimates:** the panel plots my own logged hours against the **main-story** and **100% (completionist)** benchmarks on a single line, clearly marking where I am, with a short sentence putting it in context (for example, "you're a few hours past the main story, with the long road to 100% still ahead"). My marker uses the accent color (it's *me*); the benchmarks are neutral (they're catalog facts).
+    - [x] If only one of the two benchmarks is available, the panel shows the one it has and omits the missing one rather than guessing.
+    - [x] **When the game has no time-to-beat estimates:** the panel falls back to **"Your Pace"** — a summary built only from my own data: my number of sessions, my total logged time, a simple average per session, and a small visual of my recent per-session times.
+    - [x] In both modes, the panel never fabricates a benchmark or shows an empty comparison.
+
+### 2.5 Screenshots
+
+- **As a** user, **I want to** browse the game's screenshots and view them full screen, **so that** I can enjoy and revisit the game's visuals.
+  - **Acceptance Criteria:**
+    - [x] When the game has screenshots, they appear as a strip — a row of thumbnails on desktop, a horizontally scrollable rail on phone.
+    - [x] Clicking/tapping a screenshot opens it full screen.
+    - [x] In the full-screen view I can move to the next/previous screenshot and see a row of thumbnails for jumping between them; on desktop the left/right arrow keys also move between screenshots and Escape closes the view.
+    - [x] When the game has no screenshots, the entire screenshot strip is omitted (and the hero backdrop falls back to the accent wash, per 2.1).
+
+### 2.6 About
+
+- **As a** user, **I want** a concise "About" panel with the game's description and key facts, **so that** I can remind myself what the game is and who made it.
+  - **Acceptance Criteria:**
+    - [x] The panel shows the game's summary/description when available.
+    - [x] The panel shows the release year, the developer, and the publisher, each omitted individually when unknown.
+    - [x] If none of the above (summary, release year, developer, publisher) is available, the entire About panel is omitted.
+
+### 2.7 Themes & Tags
+
+- **As a** user, **I want** the game's themes, genres, and platforms shown together as tags, **so that** I can quickly characterize the game.
+  - **Acceptance Criteria:**
+    - [x] Themes, genres, and platforms are each shown as a row of tags.
+    - [x] Platform tags use their recognizable platform colors; themes and genres use neutral styling.
+    - [x] Any row whose information is missing is omitted. If all three are missing, the entire panel is omitted.
+
+### 2.8 Journal
+
+- **As a** user, **I want** my most recent reflection on this game surfaced with a clear way to add another, **so that** my memories of the game are part of its page.
+  - **Acceptance Criteria:**
+    - [x] The panel shows my latest journal entry for the game (its date, which session it was, and a few lines of the reflection), plus a count of how many entries I have for the game.
+    - [x] The panel includes a "New entry" action that opens the same quick reflection composer as "Log a session" (2.3).
+    - [x] When I have no entries for the game yet, the panel invites me to write my first one.
+
+### 2.9 Related games
+
+- **As a** user, **I want to** see games related to this one (such as others in the same series or franchise), **so that** I can discover what to explore next.
+  - **Acceptance Criteria:**
+    - [x] When related games exist, they appear as a row of covers with titles and years, leading to those games' pages.
+    - [x] When there are no related games, the entire panel is omitted.
+
+### 2.10 Graceful behavior when information is missing
+
+- **As a** user looking at a sparse, little-known game, **I want** the page to still feel intentional and complete, **so that** it never looks broken or padded with empty boxes.
+  - **Acceptance Criteria:**
+    - [x] **Hide, never placeholder:** no panel ever shows an empty "—" value or fabricated text/scores. A piece of information that is missing is simply not rendered.
+    - [x] **Collapse a whole panel only when all of its information is missing** (for example, About disappears only when summary, release year, developer, and publisher are all unknown).
+    - [x] **Substitute personal for catalog:** where catalog information is missing, the page leans on the user's own data instead (the "Your Pace" panel standing in for external estimates is the canonical example).
+    - [x] **The worst case still works:** when a game has only a title and is in my library, the page renders a clean minimal hero (placeholder cover, title, status pill, accent-wash backdrop) plus only the personal panels that have data (Your Record, Your Pace, Journal). This matches the empty-state artboard in the handoff bundle.
+    - [x] As catalog information thins out and fewer panels remain, the layout relaxes toward a calmer single-column arrangement rather than leaving large gaps in a dense grid.
+
+### 2.11 Responsive layout and light/dark
+
+- **As a** user on any device, **I want** the page to be comfortable to read and use, **so that** it works whether I'm on my laptop or my phone.
+  - **Acceptance Criteria:**
+    - [x] On desktop, the panels are arranged in a multi-column grid within the app's normal layout.
+    - [x] On a phone, the content stacks in a single column, the screenshot strip becomes a horizontal rail, and the status control uses the bottom sheet (2.2).
+    - [x] The page reads correctly in both light and dark appearances, with the accent color consistently marking the "you" elements in both.
+
+---
+
+## 3. Scope and Boundaries
+
+### In-Scope
+
+- A single enriched game detail page that surfaces information **already available** to the app: cover, title, release year, publisher, primary/secondary genres, critic score, screenshots (with full-screen viewer), themes, developer/publisher, and related/franchise games.
+- A consolidated **Your Record** area (total logged playtime, sessions as journal-entry count, interactive star rating) with an in-place **status switcher** (popover on desktop, bottom sheet on phone) covering the five existing statuses.
+- **"Log a session"** as a fast way to add a journal entry with an **optional time-played value** and optional reflection, wired so it updates the Journal panel, the sessions count, and total playtime.
+- A **Times to Beat** comparison (the user's hours against main-story / 100% benchmarks) that **falls back to a personal "Your Pace"** view when the game has no benchmark.
+- **Graceful degradation** behavior (hide-never-placeholder, collapse-when-all-absent, substitute-personal-for-catalog, relax-toward-single-column), including the title-only worst case.
+- Basic handling for **not-in-library / signed-out** viewers (status pill becomes "Add to library"; personal panels give way to an invitation to add the game).
+- Full **light and dark** support and **desktop + mobile** responsiveness.
+
+### Out-of-Scope
+
+- **Per-game visual theming / the "Crystal Command" dialect** (game-flavored accents, command-window menus, segmented gauges). This is a separate theming concern related to the unified design-system work.
+- **Reviews** (public, short-form rated takes) and any review feed on the page.
+- **Community / aggregate stats** (how many people are playing/played, average community rating, average completion time, review counts).
+- **Playthrough timeline** and anything depending on multiple playthroughs per game.
+- The richer, fully-designed **catalog/not-in-library mode** beyond the basic "Add to library" behavior described above (can be refined in a later pass).
+
+### Out-of-Scope — separate roadmap items
+
+The following are unrelated roadmap items, automatically out of scope for this specification: Per-Playthrough Logs, Reviews, Public Reflections, the full Game Detail Redesign, Aggregate Game Stats, Bento Dashboard Reflow, Upcoming Releases Widget, YTD Stats Card, Pick Up Where You Left Off, Gaming Events Calendar, Similar Games Discovery, Browse / Catalog, Curated Collections, First-Time User Onboarding, Library View Modes, Bulk Library Actions, Global Quick-Log CTA, and all Phase 3+ platform integrations.

--- a/context/spec/023-enriched-game-detail/tasks.md
+++ b/context/spec/023-enriched-game-detail/tasks.md
@@ -1,0 +1,169 @@
+# Tasks — 023 Enriched Game Detail Page
+
+- **Functional Specification:** [`./functional-spec.md`](./functional-spec.md)
+- **Technical Considerations:** [`./technical-considerations.md`](./technical-considerations.md)
+
+---
+
+## Methodology (binding)
+
+- Each slice leaves the app in a **runnable, working state**. Verify before checking off.
+- Slices with testable TypeScript follow the **TDD policy** (RED tests authored failing first, then GREEN implementation, then refactor) — see `savepoint-tanstack/CLAUDE.md` → TDD policy.
+- UI-only changes (layout/visual) gate on a **Chrome-MCP visual pass in both Light and Dark** (desktop + mobile) against the handoff bundle (`Game Detail - Enriched.html` / `FF7 Dashboard - Prototype.html` / `Game Detail - Empty State (spec).html`).
+- Component/route tests follow the elements / actions / given-when-then shape and assert **user-observable behavior**, not call-envelope shape (see `.claude/rules/tanstack/testing.md`).
+- Respect FSD boundaries + the C2 DAL rules; mind FOOT-GUNS #1 (`.server.ts`), #2 (loader hover-preload), #8 (worker-split). No new `AppError` subclasses.
+- Commands: `pnpm --filter savepoint-tanstack {dev,typecheck,lint,format:check,test:unit,test:integration,build}`.
+- **No database migration** in this spec — every field already exists.
+- E2E deferred (consistent with project posture); per-slice verification is unit + integration + the visual gate.
+
+---
+
+## Slice 1 — Enrich the read aggregate
+
+_Delivers the data for FR 2.3 (Your Record) and FR 2.4 (Times to Beat / Your Pace); fixes the capped-at-3 sessions-count bug._
+
+- [x] RED: integration tests for `getGameDetails` — returns `journalCount` (true count, > 3 when applicable), `playtimeTotalMinutes` (null-safe `_sum`, 0 when no minutes), `recentSessionMinutes` (non-null `playedMinutes`, oldest→newest, bounded ~9); anonymous viewer (`userId` absent) → `0` / `0` / `[]`. **[Agent: testing]** — 6 failed first (RED), then 16 passed.
+- [x] GREEN: extend the authed branch of `entities/game/api/get-game-details.server.ts` with `prisma.journalEntry.count` + `prisma.journalEntry.aggregate({ _sum: { playedMinutes } })` + the recent-minutes select (fold into the existing `Promise.all`); add the three fields to the `GameDetails` type. **[Agent: prisma-database]**
+- [x] Remove the dead `relatedGames: Game[]` field from `GameDetails` and its `[]` producer — grep consumers first (`rg 'relatedGames'`) and confirm none read it. **[Agent: tanstack-fullstack]** — 4 dead sites removed; `relatedGamesSlot`/`getRelatedGamesForGameFn` (name collisions) correctly untouched.
+- [x] Gate: `test:integration` + `typecheck` + `lint` green. **[Agent: testing]** — integration 525 pass, unit 1231 pass, typecheck clean, lint exit 0.
+
+---
+
+## Slice 2 — "Log a session" captures optional minutes
+
+_Delivers FR 2.3 (the "Log a session" action), feeding playtime + Your Pace._
+
+- [x] RED: integration test — `createJournalEntryFn` (or its worker) persists optional `playedMinutes`; omitted → `null`; entry still records with empty content + no minutes. Component test — the compose dialog renders an optional "time played" field and includes it on submit. **[Agent: testing]**
+- [x] GREEN: extend `CREATE_JOURNAL_ENTRY_INPUT` in `features/compose-journal-entry/api/create-journal-entry-fn.ts` with `playedMinutes: z.number().int().positive().optional()` (validate-twice); optionally set `playSession = journalCount + 1` server-side. Split into a `.worker.ts` only if integration-testing the new branch (foot-gun #8); otherwise note the deferral. **[Agent: tanstack-fullstack]** — no worker (trivial pass-through; tested at entity query); `playSession` deferred (would force a count query + worker split).
+- [x] GREEN: add the optional numeric "time played" field to `compose-journal-entry-dialog`; keep existing `router.invalidate()` + close behavior. **[Agent: react-frontend]**
+- [x] Gate: unit + integration + typecheck/lint green; manually log a session with minutes and confirm the (existing) page data refreshes. **[Agent: testing]** — verified merged with 3a: unit 1257, integration 528, typecheck clean, lint exit 0.
+
+---
+
+## Slice 3a — Extract tab content into panel components (behavior-preserving)
+
+_Refactor toward FR 2.6/2.7/2.8/2.9 with no visible change yet — content still inside the existing `<Tabs>`._
+
+- [x] RED: tests for each new panel sub-component (`about-panel`, `themes-tags-panel`, `journal-panel`, `related-panel`) rendering their current content. **[Agent: testing]**
+- [x] GREEN: extract the Overview body into `about-panel/` (summary, released, developer, **publisher**) + `themes-tags-panel/` (themes, genres, platforms via `PlatformBadges`); extract Journal + Related into `journal-panel/` + `related-panel/` (related keeps the streamed slot). One-folder-per-component + barrels under `widgets/game-detail/ui/`. **[Agent: react-frontend]** — also surfaced themes (not shown before) + publisher per FR 2.6/2.7.
+- [x] GREEN: render the new panels inside the still-existing `<Tabs>` (no layout change) so behavior is identical. **[Agent: react-frontend]**
+- [x] Gate: unit tests + typecheck/lint green; page looks unchanged (visual diff = none). **[Agent: react-frontend]** — empty rows now collapse instead of showing em-dash (FR 2.6/2.7 behavior); 2 widget-test assertions updated accordingly.
+
+---
+
+## Slice 3b — Swap Tabs → bento grid
+
+_Delivers FR 2.11 (layout) — the structural pivot from tabs to an inline bento dashboard._
+
+- [x] RED: widget test — panels render inline with no `tablist`/`tab` roles; all ported panels present. **[Agent: testing]**
+- [x] GREEN: replace the `<Tabs>` block in `game-detail.tsx` with a responsive bento grid composing the Slice-3a panels (desktop multi-column / mobile single-column); keep the route's `Suspense` + `SectionErrorBoundary` slot wiring for streamed sections. **[Agent: react-frontend]** — `grid-cols-1 md:grid-cols-[1.35fr_1fr]`, panels wrapped in Card chrome.
+- [x] Gate: tests + Chrome-MCP visual (desktop grid + mobile single-column), Light + Dark. **[Agent: react-frontend]** — unit 1259, typecheck/lint/format green; visual via Playwright MCP (no Chrome connected) across desktop+mobile × Light+Dark.
+
+---
+
+## Slice 4 — Your Record panel
+
+_Delivers FR 2.3 (consolidated personal record)._
+
+- [x] RED: panel test — shows playtime (omitted when total is 0), sessions count, interactive `RatingInput`, and a "Log a session" button that opens the composer; saving updates count/playtime (mocked fn + invalidate). **[Agent: testing]**
+- [x] GREEN: build `widgets/game-detail/ui/your-record-panel/` from Slice-1 data + `shared/ui/rating-input` + the Slice-2 composer; place it in the bento grid. **[Agent: react-frontend]** — rating temporarily duplicated in switcher (removed in 5b); `itemId` typed `number`.
+- [x] Gate: tests + visual. **[Agent: react-frontend]** — unit 1268, typecheck/lint/format green. **Authenticated visual pass deferred to Slice 8c (panel is signed-in-only; agent has no session — declined to forge a cookie).**
+
+---
+
+## Slice 5a — Critic score ring + hero eyebrow
+
+_Delivers part of FR 2.1 (critic score; publisher in the eyebrow)._
+
+- [x] RED: tests — `critic-score-ring` renders the rounded `aggregated_rating` and is omitted when absent; hero eyebrow includes publisher and omits any missing part. **[Agent: testing]**
+- [x] GREEN: `entities/game/ui/critic-score-ring/` (display-only neutral indicator, 0–100) and add it + publisher to the hero. **[Agent: react-frontend]** — returns null when score absent; neutral (not accent).
+- [x] Gate: tests + visual (ring present vs. absent), Light + Dark. **[Agent: react-frontend]** — unit 1276, typecheck/lint/format green; **visual confirmed** (Playwright, anon-visible hero) in both themes; score-less game omits ring.
+
+---
+
+## Slice 5b — Status pill (popover / sheet) + move rating into Your Record
+
+_Delivers FR 2.2 (in-place status change). The flagged-risk slice — isolated for a clean gate._
+
+- [x] RED: tests — pill shows current status with its color/icon; on desktop opens an anchored popover, on mobile a bottom sheet, listing all 5 statuses with the current one checked; selecting mutates status and closes; not-in-library select **adds** the game. **[Agent: testing]**
+- [x] GREEN: re-present `LibraryStatusSwitcher` as the pill + adaptive menu, reusing `updateLibraryItemFn` / `addGameToLibraryFn` / `deleteLibraryItemFn` and the existing status model; "Up Next" → "Replay" when `hasBeenPlayed`. **[Agent: react-frontend]** — popover.tsx (desktop) + sheet.tsx (mobile); folder-local `use-media-query.ts` (FSD: can't import command-palette sibling).
+- [x] GREEN: remove the rating control from the switcher (it now lives in Your Record, Slice 4) — confirm no duplicate rating UI remains. **[Agent: react-frontend]** — `rg RatingInput` confirms single source in your-record-panel; widget test asserts exactly one slider.
+- [x] Gate: tests + visual (popover desktop / sheet mobile), Light + Dark. **[Agent: react-frontend]** — unit 1284, typecheck/lint/format green. **Authenticated visual deferred to Slice 8c (signed-in-only control).**
+
+---
+
+## Slice 6 — Screenshots panel + lightbox
+
+_Delivers FR 2.5._
+
+- [x] RED: tests — `shared/ui/image-lightbox` opens on a thumbnail, navigates with prev/next + ←/→ keys, closes on Esc and on backdrop click; `screenshots-panel` is omitted entirely when there are no screenshots. **[Agent: testing]**
+- [x] GREEN: build `shared/ui/image-lightbox/` over `shared/ui/dialog.tsx`; build `widgets/game-detail/ui/screenshots-panel/` (thumbnail grid desktop / horizontal rail mobile) using `buildScreenshotUrl`. **[Agent: react-frontend]** — generic controlled lightbox (wrap-around nav); panel full-width `md:col-span-2`, omitted when no screenshots.
+- [x] Gate: tests + visual (gallery + lightbox, desktop + mobile). **[Agent: react-frontend]** — unit 1301, typecheck/lint/format green; **visual confirmed** (Playwright, anon) both themes; no-panel path unit-covered (seed games always have screenshots).
+
+---
+
+## Slice 7 — Times to Beat (you-vs-benchmark) + Your Pace fallback
+
+_Delivers FR 2.4._
+
+- [x] RED: tests — **benchmark mode** plots the viewer's logged hours against main-story / 100% (accent marker, neutral benchmarks, context sentence; single tick when only one benchmark); **`null` benchmark** → `your-pace-panel` (sessions, total, average, recent-session bars from `recentSessionMinutes`). **[Agent: testing]**
+- [x] GREEN: extend `features/game-detail/ui/times-to-beat-section` with the beat line (seconds→hours); add `features/game-detail/ui/your-pace-panel/`. **[Agent: react-frontend]** — accent="you", benchmarks neutral; single tick when one benchmark.
+- [x] GREEN: in `routes/games.$slug.tsx`, build the times-to-beat slot to pass **both** the streamed benchmark and the loader's personal stats, choosing benchmark vs. pace mode by whether the benchmark is `null`. **[Agent: tanstack-fullstack]** — slot no longer suppresses on null benchmark; no new server fn.
+- [x] Gate: tests + visual (both states). **[Agent: react-frontend]** — unit 1313, typecheck/lint/format green; benchmark mode **visual confirmed** (Playwright, anon); authenticated you-marker + pace deferred to 8c.
+
+---
+
+## Slice 8a — Graceful degradation rules
+
+_Delivers FR 2.10 (hide-never-placeholder, collapse-when-all-absent, accent-wash, title-only worst case)._
+
+- [x] RED: tests — each panel collapses when **all** its inputs are absent (About, Themes & Tags, Screenshots, Related); no "—" placeholders anywhere; title-only-in-library worst case renders only hero + Your Record + Your Pace + Journal with the accent-wash backdrop. **[Agent: testing]**
+- [x] GREEN: apply per-panel presence guards + collapse rules across the bento; confirm the existing accent-wash backdrop fallback path. **[Agent: react-frontend]** — closed catalog-Card + Related-Card empty-box gaps (Related chrome moved to route, the only layer that sees the streamed null); AboutPanel full-collapse made explicit.
+- [x] Gate: tests + visual against the empty-state spec artboard. **[Agent: react-frontend]** — unit 1323, typecheck/lint/format green; anon sparse render confirmed (Playwright); title-only-in-library worst case unit-covered, authenticated visual deferred to 8c.
+
+---
+
+## Slice 8b — Not-in-library / logged-out mode
+
+_Delivers FR 2.2 (Add to library) + the catalog-viewer behavior._
+
+- [x] RED: tests — when not in library (or `viewerUserId` null), the status pill is replaced by an "Add to library" action (or sign-in prompt when logged out), and the personal panels (Your Record / Your Pace / Journal) give way to a single "Add this to start tracking" invitation. **[Agent: testing]**
+- [x] GREEN: implement the not-in-library / logged-out branch in the hero + bento (reuse `add-game` feature). **[Agent: react-frontend]** — `add-to-track-invite/` (signed-in→AddFromGameDetailButton; logged-out→Sign in link); times-to-beat slot treated as personal (suppressed when logged out — **flagged for review**).
+- [x] Gate: tests + visual (in-library vs. not-in-library vs. logged-out). **[Agent: react-frontend]** — unit 1333, typecheck/lint/format green; logged-out **visual confirmed** (Playwright, both themes); signed-in not-in-library deferred to 8c.
+
+---
+
+## Slice 8c — Responsive reflow + final gate
+
+_Delivers FR 2.11 (responsive + Light/Dark) and the whole-spec verification._
+
+- [x] Polish the mobile single-column reflow (screenshot rail, status sheet, panel order) and the desktop grid relaxation as panels collapse. **[Agent: react-frontend]** — already satisfied by slices 3b/6/8a (`md:items-start`, horizontal rail, single-column stack); no layout code change needed, confirmed by anon visual sweep.
+- [x] Final gate: full `test:unit` + `test:integration` + `typecheck` + `lint` + `format:check` + `build` green (coverage gate: statements ≥ 85 on `src/{entities,features}`); Chrome-MCP visual sweep across in-library / sparse / title-only, Light + Dark, desktop + mobile. **[Agent: react-frontend]** — unit 1337, integration 528, typecheck/lint/format/build green, coverage 85.06% stmts (2 tests added to clear it); anon sweep (rich+sparse × Light/Dark × desktop/mobile) clean. **Authenticated visual sweep (5 signed-in surfaces) left for the human — see below.**
+
+---
+
+## Agent / verification notes
+
+- All sub-tasks map to existing specialists (`testing`, `react-frontend`, `tanstack-fullstack`, `prisma-database`) — no `general-purpose` fallbacks.
+- All slices verified via unit + integration + typecheck/lint/format/build + coverage (85.06% stmts) and **anonymous** Playwright visual passes. Chrome MCP had no connected browser; Playwright MCP was used instead.
+
+## Pending: authenticated visual verification (human, with a signed-in session)
+
+Agents could not run these — the surfaces are signed-in-only and forging a session cookie was (correctly) refused. Each is covered by unit tests; only the visual confirmation in a real session remains. Verify Light + Dark, desktop (≥1280px) + mobile (390px):
+
+1. **Your Record** — playtime (omitted when 0), sessions count, interactive star rating, "Log a session" → composer opens → save updates count/playtime/journal.
+2. **Status pill** — desktop anchored **popover** vs mobile bottom **sheet**; select mutates + closes; "Up Next" → "Replay" when played.
+3. **Times to Beat (benchmark mode) with the accent "You" marker** for an in-library viewer with logged hours; **Your Pace fallback** for an in-library game with no benchmark.
+4. **Title-only-in-library worst case** — minimal hero (placeholder cover, title, status pill, accent-wash backdrop) + only Your Record / Your Pace / Journal; no catalog surfaces; no em-dash.
+5. **Signed-in not-in-library** — hero "Add to library" + the single "Add this to start tracking" invitation replacing the personal panels.
+
+## Open product question (flagged, not blocking)
+
+- The **times-to-beat slot is suppressed entirely for logged-out viewers** (treated as part of the personal "you" layer). Matches §2.4's framing, but anonymous visitors then never see the catalog benchmark line. Confirm this is desired, or have anon users see the bare benchmark (no "You" marker).
+
+## Post-implementation refinements (2026-06-03, user review)
+
+- **Bento order corrected to match the Claude Design prototype.** The build had drifted (screenshots buried mid-grid; About+Themes merged into one catalog card; Times to Beat pushed away from Your Record). Restored: full-width **Screenshots strip above the grid**, then **Your Record │ Times to Beat**, **About │ Themes & Tags**, **Journal │ Related**. About/Themes un-merged into two separate self-omitting cards (each `Card` gated on its own `hasAboutData`/`hasThemesTagsData`, so no empty box). Related card chrome still owned by the route. unit 1339, typecheck/lint/format/build green; anon Playwright confirmed.
+- **Game-detail panels use `Card variant="flat"`** (no hover). The panels are read-only surfaces; the default Card's hover affordance was wrong here. Used the **pre-existing `flat` variant** in `shared/ui/card.tsx` (no new variant, no per-instance override) on all 10 cards (7 widget + 3 route Related states). unit 1339, typecheck/lint/format green.
+- **Platform badges colored by family (completes FR 2.7).** The `playstation`/`xbox`/`nintendo`/`pc` Badge variants + `--color-*` tokens already existed but `PlatformBadges` rendered everything `subtle`. Added a single `getPlatformFamily(name)` classifier (4 families + neutral tail; mobile-exclusion guard so "Windows Phone" → other) + `getPlatformBadgeVariant`, wired into `PlatformBadges`. Also fixed a latent bug: short token "nes" was substring-matching "geNESis" → Sega got a Nintendo glyph (now whole-word matched). unit 1364 green.
+- **Cards adopt the colored badges.** Game card now reuses `<PlatformBadges>` (glyph + abbreviation + family color + +N overflow) instead of hand-rolled grey chips; library card's single-platform badge uses the family variant. `getPlatformFamily`/`getPlatformBadgeVariant` exported through the `@/entities/game` barrel. unit 1368 green.

--- a/context/spec/023-enriched-game-detail/technical-considerations.md
+++ b/context/spec/023-enriched-game-detail/technical-considerations.md
@@ -1,0 +1,165 @@
+<!--
+Architectural HOW for spec 023. Contracts and file responsibilities, not implementations.
+All paths are under savepoint-tanstack/ unless noted.
+-->
+
+# Technical Specification: Enriched Game Detail Page
+
+- **Functional Specification:** [`./functional-spec.md`](./functional-spec.md)
+- **Status:** Completed
+- **Author(s):** Nail Badiullin (with AI assistance)
+
+---
+
+## 1. High-Level Technical Approach
+
+This is **~90% a recomposition of existing, tested pieces** into a new layout, not a greenfield build. The current game-detail page (`src/widgets/game-detail/ui/game-detail/game-detail.tsx`) renders a hero plus a `<Tabs>` block (Overview / Journal / Related / Times-to-beat). We replace the tabs with a single **inline bento layout** of panels, folding every tab's content into the page, and add the personal "your record / your pace" machinery and a screenshot gallery.
+
+The work touches three layers, in line with the C2 DAL + FSD rules:
+
+- **`entities/`** — extend the existing `getGameDetails` read aggregate to also return the true journal **session count**, **total logged playtime**, and a short **recent-session-minutes** series (fixing a real bug where today's count is capped at 3). No schema migration.
+- **`features/`** — extend `createJournalEntryFn` to accept an **optional "minutes played"** value (the `JournalEntry.playedMinutes` field already exists); re-present the existing status switcher as a **pill + adaptive menu** (popover on desktop, bottom sheet on mobile). Reuse `getTimesToBeatForGameFn` and `getRelatedGamesForGameFn` unchanged (still streamed).
+- **`widgets/` + `shared/ui/`** — recompose `widgets/game-detail/` into bento panel sub-components; add a reusable **image lightbox** primitive in `shared/ui/`.
+
+Read-path strategy is unchanged: core data stays **eager in the route loader** (via the existing `getGameDetailPageDataFn` wrapper — preserving the loader-direct bundler caveat), while **times-to-beat and related games stay client-streamed** via `useSuspenseQuery` behind the route's `Suspense` + `SectionErrorBoundary`. The journal compose dialog continues to call `router.invalidate()`, which now also refreshes the count and playtime because they live in the loader aggregate.
+
+---
+
+## 2. Proposed Solution & Implementation Plan (The "How")
+
+### 2.1 Data Model / Database Changes
+
+**No migration.** Every field needed already exists. Relevant columns:
+
+| Model | Field | Use in this feature |
+|---|---|---|
+| `LibraryItem` | `status` (`LibraryItemStatus`) | Status pill — 5 values (WISHLIST/SHELF/UP_NEXT/PLAYING/PLAYED) |
+| `LibraryItem` | `rating` (`Int?`, 1–10 half-step) | Interactive star rating |
+| `LibraryItem` | `hasBeenPlayed` (`Boolean`) | "Up Next" → "Replay" label |
+| `JournalEntry` | `playedMinutes` (`Int?`) | Per-session time; summed → total playtime; series → Your Pace bars |
+| `JournalEntry` | `playSession` (`Int?`) | Session ordinal (display; optionally auto-set on create) |
+| `JournalEntry` | `content`, `kind`, `gameId` | Existing journal entry shape |
+
+Derived values (computed in the read aggregate, not stored):
+- **Total playtime (minutes)** = `SUM(JournalEntry.playedMinutes)` for `(userId, gameId)`.
+- **Sessions** = `COUNT(JournalEntry)` for `(userId, gameId)`.
+- **Recent-session series** = `playedMinutes` of the most recent ~9 entries (non-null), oldest→newest, for the Your Pace bars.
+
+### 2.2 Read Aggregate Changes
+
+**File:** `src/entities/game/api/get-game-details.server.ts` (entity query, `.server.ts`).
+
+Extend the `GameDetails` return shape (within the existing `if (userId)` branch, using `Promise.all` alongside the current `findFirst` / `findMany`):
+
+| Field | Type | Source |
+|---|---|---|
+| `journalCount` | `number` | `prisma.journalEntry.count({ where: { userId, gameId } })` |
+| `playtimeTotalMinutes` | `number` | `prisma.journalEntry.aggregate({ _sum: { playedMinutes } })` (null → 0) |
+| `recentSessionMinutes` | `number[]` | recent entries' `playedMinutes`, non-null, oldest→newest |
+
+Also **remove the dead `relatedGames: Game[]` field** (always `[]`; "kept for backward-compat") while reshaping — confirm no consumer reads it first. Per the **"no specialized subset query"** rule, fold these into this aggregate rather than adding standalone `count` / `sum` entity queries. Anonymous viewers (`userId` absent) get `journalCount: 0`, `playtimeTotalMinutes: 0`, `recentSessionMinutes: []`.
+
+> The route loader keeps calling `getGameDetailPageDataFn` (`src/features/game-detail/api/get-game-detail-page-data.ts`), which already wraps the entity query in a `createServerFn` — do **not** switch the loader to a top-level `.server.ts` import (foot-gun #2 hover-preload hang).
+
+### 2.3 Mutation Changes — "Log a session" captures optional minutes
+
+**File:** `src/features/compose-journal-entry/api/create-journal-entry-fn.ts`.
+
+Extend `CREATE_JOURNAL_ENTRY_INPUT` with an optional `playedMinutes: z.number().int().positive().optional()` (and optionally set `playSession` server-side to `journalCount + 1`). Apply **validate-twice** (inputValidator + handler re-parse) and keep `requireUserId()`. The downstream entity create query persists `playedMinutes`.
+
+**Worker-split (foot-gun #8):** the handler now does conditional logic (optional fields, possible ordinal derivation). If integration coverage of the new branch is wanted, split into `create-journal-entry-fn.worker.ts` (plain async, owns its `UnauthorizedError` gate) + a thin `createServerFn` wrapper; integration tests import the worker. If the handler stays a trivial pass-through to the entity query, the split can be deferred — note the decision in the task list.
+
+**Dialog:** `src/features/compose-journal-entry/ui/compose-journal-entry-dialog/` gains an **optional numeric "time played" field**. Existing success behavior (`router.invalidate()` then close) is unchanged and now also refreshes count + playtime.
+
+### 2.4 Reused As-Is (no change)
+
+- **Status mutations:** `updateLibraryItemFn`, `addGameToLibraryFn`, `deleteLibraryItemFn` (rating bound 1–10 already enforced in `update-library-item-fn.ts`).
+- **`RatingInput`** (`src/shared/ui/rating-input.tsx`) — interactive, half-step, keyboard-accessible.
+- **`getTimesToBeatForGameFn`** + `getTimesToBeat` entity query — returns `{ mainStory, completionist }` in **seconds**; streamed.
+- **`getRelatedGamesForGameFn`** + `RelatedGamesTabs` / `RelatedGamesSkeleton` — streamed `RelatedCollectionSection[]`.
+- **`JournalTeaser`** (entity ui), **`GameCover`**, **`PlatformBadges`** (entity ui), **`buildScreenshotUrl`** / **`buildCoverImageUrl`** (`shared/lib/igdb-image.ts`).
+
+### 2.5 Component Breakdown
+
+New / changed UI, each as a one-folder-per-component unit with a barrel + `.type.ts` + colocated `.test.tsx`.
+
+**`widgets/game-detail/ui/` (layout owner — composes features + entities + shared/ui):**
+
+| Component | Responsibility |
+|---|---|
+| `game-detail/` (existing) | Replace `<Tabs>` with the bento grid (desktop multi-column / mobile single-column); render hero + panels; keep slot props for streamed sections |
+| `game-detail-hero/` | Cover, eyebrow (year · publisher · primary genre — each omitted if absent), title, critic score ring, status pill |
+| `your-record-panel/` | Total playtime (omit if 0), sessions count, `RatingInput`, "Log a session" button |
+| `screenshots-panel/` | Thumbnail grid (desktop) / horizontal rail (mobile); opens the lightbox; omitted entirely if no screenshots |
+| `about-panel/` | Summary + released/developer/publisher; whole panel omitted if all absent |
+| `themes-tags-panel/` | Themes / genres / platforms rows (platform brand colors via `PlatformBadges`); per-row omit; whole panel omitted if all absent |
+| `journal-panel/` | Latest entry teaser + entry count + "New entry"; empty-invite when none |
+| `related-panel/` | Wraps the streamed related-games slot; omitted when no sections |
+
+**`features/game-detail/ui/`:**
+
+| Component | Responsibility |
+|---|---|
+| `times-to-beat-section/` (existing — extend) | Render the **you-vs-benchmark line**: convert benchmark seconds→hours, plot the viewer's logged hours against main-story / 100%, accent marker + neutral benchmarks + context sentence |
+| `your-pace-panel/` (new) | Fallback when times-to-beat is `null`: sessions, total, average, recent-session bars from `recentSessionMinutes` |
+
+**`entities/game/ui/`:**
+
+| Component | Responsibility |
+|---|---|
+| `critic-score-ring/` (new, display-only) | Circular indicator for `aggregated_rating` (0–100, rounded); a neutral catalog fact |
+
+**`features/manage-library-entry/` (or the existing switcher folder):** re-present `LibraryStatusSwitcher` as a **status pill** that opens an anchored **popover (desktop)** / **bottom sheet (mobile)** listing the 5 statuses with the current one checked, reusing the existing mutation calls and the not-in-library "select adds the game" behavior. (See Risk 3.)
+
+**`shared/ui/`:**
+
+| Component | Responsibility |
+|---|---|
+| `image-lightbox/` (new) | Full-screen viewer over the existing `dialog.tsx`: large image, prev/next, thumbnail strip, ←/→/Esc keys. Reusable, presentational |
+
+### 2.6 Route Wiring
+
+**File:** `src/routes/games.$slug.tsx`. The route already has the loader `data` (now carrying `playtimeTotalMinutes`, `journalCount`, `recentSessionMinutes`) and renders the streamed `timesToBeatSlot`. Build that slot to pass **both** the streamed benchmark and the loader-derived personal stats into `TimesToBeatSection`, so the panel chooses **benchmark mode** (benchmark present) vs **Your Pace mode** (benchmark `null`). Keep `Suspense` + `SectionErrorBoundary` in the route (widgets rule: route owns plumbing).
+
+### 2.7 Logic / Algorithm Notes
+
+- **Hours formatting:** benchmark seconds → hours (`/3600`); playtime minutes → hours (`/60`); round per existing `times-to-beat-section` convention.
+- **Beat line:** plot viewer hours against `mainStory` / `completionist`; show "Xh past/from main story" + remaining-to-100% sentence; if only one benchmark present, render only that tick.
+- **Degradation (functional-spec §2.10):** each panel's render is guarded by its data presence; a panel collapses only when **all** its inputs are absent; the title-only worst case yields hero + Your Record + (Your Pace) + Journal only, with the accent-wash backdrop fallback (already implemented in the current hero).
+
+---
+
+## 3. Impact and Risk Analysis
+
+### System Dependencies
+
+- **IGDB** (`/games`, `/game_time_to_beats`, `/collections`) — unchanged usage; failures already surface as `UpstreamError` and degrade per-section.
+- **Prisma / Postgres** — two extra cheap aggregates (`count`, `_sum`) on `JournalEntry`, already indexed by `gameId`; in the same authed branch as the current reads.
+- **Existing mutations** — status/rating/journal flows are reused; behavior must remain intact.
+
+### Potential Risks & Mitigations
+
+1. **Heavily-tested widget rebuild.** `game-detail` and its pieces carry substantial tests. *Mitigation:* TDD per the binding methodology — author panel tests RED first; preserve the route's `errorComponent` / `SectionErrorBoundary` behavior; keep the coverage gate (statements ≥ 85 on `src/{entities,features}`) green.
+2. **Count/playtime correctness.** Today's sessions badge is `journalTeaser.length` (capped at 3) — a latent bug. *Mitigation:* integration-test the new aggregate against real PG (0 entries, >3 entries, null vs set `playedMinutes`).
+3. **Status-control re-presentation (decided: convert to pill).** The design unifies on a **pill → popover (desktop) / bottom sheet (mobile)**; today it's an inline `SegmentedControl`. This is the single largest behavioral change — it rewrites tested interaction surface. *Mitigation:* reuse the same mutations and status model unchanged; rewrite only the switcher's presentation and its tests together, keeping the not-in-library "select adds the game" behavior intact.
+4. **Removing the dead `relatedGames` field.** *Mitigation:* grep consumers before deletion; it's documented as always-empty.
+5. **Extending `createJournalEntryFn` input.** Optional field is backward-compatible. *Mitigation:* validate-twice; add the worker split only if integration-testing the new branch (foot-gun #8).
+6. **App shell / mobile chrome.** The design mocks a sidebar + bottom tab bar; those belong to the existing app shell and are **out of scope** — this page must lay out correctly *within* the current shell on mobile and desktop.
+
+---
+
+## 4. Testing Strategy
+
+Per the binding TDD methodology (tests precede implementation; RED → GREEN → refactor) and the two-project Vitest setup.
+
+- **Entity aggregate (integration, real PG):** `getGameDetails` returns correct `journalCount`, `playtimeTotalMinutes` (sum, null-safe), and `recentSessionMinutes` ordering; anonymous viewer gets zeroed personal fields.
+- **Mutation (integration, real PG):** `createJournalEntryFn` (or its worker) persists optional `playedMinutes`; omitted minutes leave it null; entry still records with empty content + no minutes.
+- **Component (unit, jsdom)** — following the elements / actions / given-when-then shape, asserting **user-observable behavior** (not call-envelope shape):
+  - Each panel renders its data and **collapses when its data is absent**; title-only worst case shows only hero + personal panels.
+  - Times-to-beat panel shows the **benchmark line** when a benchmark is present and the **Your Pace** fallback when it is `null`.
+  - "Log a session" opens the composer, accepts optional minutes, and on save the count/playtime/journal update (via mocked server fn + invalidate).
+  - Status pill opens popover (desktop) / sheet (mobile), reflects current status, and triggers the mutation on select; not-in-library shows "Add to library".
+  - Screenshot lightbox opens, navigates with arrows/keys, and closes on Esc.
+  - Interactive rating sets/clears via `RatingInput`.
+- **Regression floors:** keep `test/eslint/` (FSD boundary) and `test/canary/` harness sentinels intact; respect `eslint-plugin-boundaries`.
+- **E2E:** deferred (consistent with current project posture).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: 1.132.0
         version: 1.132.0(@tanstack/react-router@1.170.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@22.10.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       better-auth:
-        specifier: 1.6.9
-        version: 1.6.9(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/react-start@1.168.6(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@8.0.11(@types/node@22.10.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(next@16.2.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(solid-js@1.9.12)(vitest@4.1.5)
+        specifier: 1.6.11
+        version: 1.6.11(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/react-start@1.168.6(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@8.0.11(@types/node@22.10.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(next@16.2.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(solid-js@1.9.12)(vitest@4.1.5)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -613,8 +613,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.6.9':
-    resolution: {integrity: sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==}
+  '@better-auth/core@1.6.11':
+    resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
     peerDependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
@@ -630,46 +630,46 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.9':
-    resolution: {integrity: sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==}
+  '@better-auth/drizzle-adapter@1.6.11':
+    resolution: {integrity: sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
       drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.9':
-    resolution: {integrity: sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==}
+  '@better-auth/kysely-adapter@1.6.11':
+    resolution: {integrity: sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
-      kysely: ^0.28.14
+      kysely: ^0.28.17
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.9':
-    resolution: {integrity: sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==}
+  '@better-auth/memory-adapter@1.6.11':
+    resolution: {integrity: sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.9':
-    resolution: {integrity: sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==}
+  '@better-auth/mongo-adapter@1.6.11':
+    resolution: {integrity: sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/prisma-adapter@1.6.9':
-    resolution: {integrity: sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==}
+  '@better-auth/prisma-adapter@1.6.11':
+    resolution: {integrity: sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -679,10 +679,10 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.9':
-    resolution: {integrity: sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==}
+  '@better-auth/telemetry@1.6.11':
+    resolution: {integrity: sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.9
+      '@better-auth/core': ^1.6.11
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -3179,8 +3179,8 @@ packages:
     resolution: {integrity: sha512-Mh++g+2LPfzZToywfE1BUzvZbfOY52Nil0rn9H1CPC5DJ7fX+Vir7nToBeoiSbB1zTNeGYbELEvJESujgGrzXw==}
     hasBin: true
 
-  better-auth@1.6.9:
-    resolution: {integrity: sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==}
+  better-auth@1.6.11:
+    resolution: {integrity: sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -6643,7 +6643,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
@@ -6655,39 +6655,39 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/prisma-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))':
+  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       '@prisma/client': 7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2)
       prisma: 7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2)
 
-  '@better-auth/telemetry@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -9254,15 +9254,15 @@ snapshots:
 
   baseline-browser-mapping@2.9.0: {}
 
-  better-auth@1.6.9(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/react-start@1.168.6(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@8.0.11(@types/node@22.10.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(next@16.2.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(solid-js@1.9.12)(vitest@4.1.5):
+  better-auth@1.6.11(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/react-start@1.168.6(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@8.0.11(@types/node@22.10.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(next@16.2.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(solid-js@1.9.12)(vitest@4.1.5):
     dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))
-      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))(typescript@6.0.2))(prisma@7.6.0(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@6.0.2))
+      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.1.13))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0

--- a/savepoint-tanstack/.prettierignore
+++ b/savepoint-tanstack/.prettierignore
@@ -1,5 +1,6 @@
 node_modules/**
 dist/**
+coverage/**
 .tanstack/**
 src/routeTree.gen.ts
 shared/lib/prisma/**

--- a/savepoint-tanstack/package.json
+++ b/savepoint-tanstack/package.json
@@ -54,7 +54,7 @@
     "@tanstack/react-router-ssr-query": "1.167.0",
     "@tanstack/react-start": "1.168.6",
     "@tanstack/router-plugin": "1.132.0",
-    "better-auth": "1.6.9",
+    "better-auth": "1.6.11",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/savepoint-tanstack/src/entities/game/api/get-game-details.server.ts
+++ b/savepoint-tanstack/src/entities/game/api/get-game-details.server.ts
@@ -24,6 +24,8 @@ export interface GameDetails {
   journalCount: number;
   /** SUM of the viewer's logged playedMinutes for this game; 0 when none. */
   playtimeTotalMinutes: number;
+  /** Count of journal entries carrying non-null playedMinutes — the true denominator for average session length. */
+  playtimeSessionCount: number;
   /** Recent non-null playedMinutes, oldest→newest, bounded for a rhythm chart. */
   recentSessionMinutes: number[];
 }
@@ -45,6 +47,7 @@ export async function getGameDetails(params: {
   let journalTeaser: JournalEntry[] = [];
   let journalCount = 0;
   let playtimeTotalMinutes = 0;
+  let playtimeSessionCount = 0;
   let recentSessionMinutes: number[] = [];
 
   if (userId) {
@@ -65,6 +68,7 @@ export async function getGameDetails(params: {
         prisma.journalEntry.aggregate({
           where: { userId, gameId: game.id },
           _sum: { playedMinutes: true },
+          _count: { playedMinutes: true },
         }),
         prisma.journalEntry.findMany({
           where: { userId, gameId: game.id, playedMinutes: { not: null } },
@@ -78,6 +82,7 @@ export async function getGameDetails(params: {
     journalTeaser = teaser;
     journalCount = count;
     playtimeTotalMinutes = playtimeAggregate._sum.playedMinutes ?? 0;
+    playtimeSessionCount = playtimeAggregate._count.playedMinutes;
     // Fetched newest→oldest for the "most recent" bound; reverse to oldest→newest
     // so the rhythm chart reads left-to-right.
     recentSessionMinutes = recentMinutesRows
@@ -92,6 +97,7 @@ export async function getGameDetails(params: {
     journalTeaser,
     journalCount,
     playtimeTotalMinutes,
+    playtimeSessionCount,
     recentSessionMinutes,
   };
 }

--- a/savepoint-tanstack/src/entities/game/api/get-game-details.server.ts
+++ b/savepoint-tanstack/src/entities/game/api/get-game-details.server.ts
@@ -13,13 +13,19 @@ import type {
 import { upsertThinGameFromIgdbDetailsPayload } from "./upsert-game.server";
 
 const JOURNAL_TEASER_LIMIT = 3;
+const RECENT_SESSION_LIMIT = 9;
 
 export interface GameDetails {
   game: Game;
   igdbDetails: GameDetailsResponseItem;
-  relatedGames: Game[];
   libraryEntry: LibraryItem | null;
   journalTeaser: JournalEntry[];
+  /** True count of the viewer's journal entries — NOT capped at the teaser limit. */
+  journalCount: number;
+  /** SUM of the viewer's logged playedMinutes for this game; 0 when none. */
+  playtimeTotalMinutes: number;
+  /** Recent non-null playedMinutes, oldest→newest, bounded for a rhythm chart. */
+  recentSessionMinutes: number[];
 }
 
 export async function getGameDetails(params: {
@@ -37,23 +43,55 @@ export async function getGameDetails(params: {
 
   let libraryEntry: LibraryItem | null = null;
   let journalTeaser: JournalEntry[] = [];
+  let journalCount = 0;
+  let playtimeTotalMinutes = 0;
+  let recentSessionMinutes: number[] = [];
 
   if (userId) {
-    [libraryEntry, journalTeaser] = await Promise.all([
-      prisma.libraryItem.findFirst({
-        where: { userId, gameId: game.id },
-        orderBy: { updatedAt: "desc" },
-      }),
-      prisma.journalEntry.findMany({
-        where: { userId, gameId: game.id },
-        orderBy: { createdAt: "desc" },
-        take: JOURNAL_TEASER_LIMIT,
-      }),
-    ]);
+    const [entry, teaser, count, playtimeAggregate, recentMinutesRows] =
+      await Promise.all([
+        prisma.libraryItem.findFirst({
+          where: { userId, gameId: game.id },
+          orderBy: { updatedAt: "desc" },
+        }),
+        prisma.journalEntry.findMany({
+          where: { userId, gameId: game.id },
+          orderBy: { createdAt: "desc" },
+          take: JOURNAL_TEASER_LIMIT,
+        }),
+        prisma.journalEntry.count({
+          where: { userId, gameId: game.id },
+        }),
+        prisma.journalEntry.aggregate({
+          where: { userId, gameId: game.id },
+          _sum: { playedMinutes: true },
+        }),
+        prisma.journalEntry.findMany({
+          where: { userId, gameId: game.id, playedMinutes: { not: null } },
+          orderBy: { createdAt: "desc" },
+          take: RECENT_SESSION_LIMIT,
+          select: { playedMinutes: true },
+        }),
+      ]);
+
+    libraryEntry = entry;
+    journalTeaser = teaser;
+    journalCount = count;
+    playtimeTotalMinutes = playtimeAggregate._sum.playedMinutes ?? 0;
+    // Fetched newest→oldest for the "most recent" bound; reverse to oldest→newest
+    // so the rhythm chart reads left-to-right.
+    recentSessionMinutes = recentMinutesRows
+      .map((row) => row.playedMinutes as number)
+      .reverse();
   }
 
-  // relatedGames kept for backward-compat; live surface is deferredRelatedGames in the loader.
-  const relatedGames: Game[] = [];
-
-  return { game, igdbDetails, relatedGames, libraryEntry, journalTeaser };
+  return {
+    game,
+    igdbDetails,
+    libraryEntry,
+    journalTeaser,
+    journalCount,
+    playtimeTotalMinutes,
+    recentSessionMinutes,
+  };
 }

--- a/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.test.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CriticScoreRing } from "./critic-score-ring";
+
+const elements = {
+  queryScore: (rounded: string) => screen.queryByText(rounded),
+  queryByCriticLabel: () => screen.queryByLabelText("Critic score"),
+  queryCriticOverline: () => screen.queryByText("Critic score"),
+};
+
+describe("CriticScoreRing", () => {
+  describe("given a fractional 0-100 score", () => {
+    beforeEach(() => {
+      render(<CriticScoreRing value={87.6} />);
+    });
+
+    it("renders the rounded numeric score", () => {
+      expect(elements.queryScore("88")).not.toBeNull();
+    });
+
+    it("exposes an accessible 'Critic score' label", () => {
+      expect(elements.queryByCriticLabel()).not.toBeNull();
+    });
+
+    it("shows the 'Critic score' overline caption", () => {
+      expect(elements.queryCriticOverline()).not.toBeNull();
+    });
+  });
+
+  describe("given a score that rounds down", () => {
+    beforeEach(() => {
+      render(<CriticScoreRing value={74.2} />);
+    });
+
+    it("renders the floored rounded score", () => {
+      expect(elements.queryScore("74")).not.toBeNull();
+    });
+  });
+
+  describe("given a null score", () => {
+    beforeEach(() => {
+      render(<CriticScoreRing value={null} />);
+    });
+
+    it("renders nothing", () => {
+      expect(elements.queryByCriticLabel()).toBeNull();
+      expect(elements.queryCriticOverline()).toBeNull();
+    });
+  });
+
+  describe("given an undefined score", () => {
+    beforeEach(() => {
+      render(<CriticScoreRing value={undefined} />);
+    });
+
+    it("renders nothing", () => {
+      expect(elements.queryByCriticLabel()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.tsx
@@ -16,8 +16,8 @@ export function CriticScoreRing({ value }: CriticScoreRingProps) {
     return null;
   }
 
-  const rounded = Math.round(value);
-  const degrees = Math.max(0, Math.min(100, rounded)) * 3.6;
+  const clamped = Math.max(0, Math.min(100, Math.round(value)));
+  const degrees = clamped * 3.6;
 
   return (
     <div
@@ -33,7 +33,7 @@ export function CriticScoreRing({ value }: CriticScoreRingProps) {
       >
         <div className="bg-card absolute inset-[7px] flex flex-col items-center justify-center rounded-full">
           <span className="text-foreground text-xl leading-none font-bold tabular-nums">
-            {rounded}
+            {clamped}
           </span>
         </div>
       </div>

--- a/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.tsx
@@ -1,0 +1,45 @@
+import type { CriticScoreRingProps } from "./critic-score-ring.type";
+
+/**
+ * Display-only circular indicator for a game's critic score (IGDB
+ * aggregated_rating, 0-100). NEUTRAL styling — a catalog fact, not "you".
+ * The filled arc uses --foreground; the remaining track is a faded
+ * --muted-foreground. Hidden entirely when no score is available.
+ *
+ * The conic-gradient angle is data-driven and the fill/track colors are
+ * token-based color-mix expressions, so it is expressed via inline style
+ * with CSS custom properties rather than Tailwind utilities (no arbitrary
+ * hex values are introduced).
+ */
+export function CriticScoreRing({ value }: CriticScoreRingProps) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const rounded = Math.round(value);
+  const degrees = Math.max(0, Math.min(100, rounded)) * 3.6;
+
+  return (
+    <div
+      role="img"
+      aria-label="Critic score"
+      className="flex flex-col items-center gap-1.5"
+    >
+      <div
+        className="relative size-[76px] shrink-0 rounded-full"
+        style={{
+          background: `conic-gradient(var(--foreground) ${degrees}deg, color-mix(in oklch, var(--muted-foreground) 20%, transparent) ${degrees}deg)`,
+        }}
+      >
+        <div className="bg-card absolute inset-[7px] flex flex-col items-center justify-center rounded-full">
+          <span className="text-foreground text-xl leading-none font-bold tabular-nums">
+            {rounded}
+          </span>
+        </div>
+      </div>
+      <span className="text-caption text-muted-foreground tracking-wider uppercase">
+        Critic score
+      </span>
+    </div>
+  );
+}

--- a/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.type.ts
+++ b/savepoint-tanstack/src/entities/game/ui/critic-score-ring/critic-score-ring.type.ts
@@ -1,0 +1,4 @@
+export type CriticScoreRingProps = {
+  /** IGDB aggregated_rating (0-100). Null/undefined hides the ring entirely. */
+  value: number | null | undefined;
+};

--- a/savepoint-tanstack/src/entities/game/ui/critic-score-ring/index.ts
+++ b/savepoint-tanstack/src/entities/game/ui/critic-score-ring/index.ts
@@ -1,0 +1,2 @@
+export { CriticScoreRing } from "./critic-score-ring";
+export type { CriticScoreRingProps } from "./critic-score-ring.type";

--- a/savepoint-tanstack/src/entities/game/ui/index.ts
+++ b/savepoint-tanstack/src/entities/game/ui/index.ts
@@ -1,6 +1,12 @@
+export { CriticScoreRing } from "./critic-score-ring";
+export type { CriticScoreRingProps } from "./critic-score-ring";
 export { GameCover } from "./game-cover";
 export type { GameCoverProps } from "./game-cover";
 export { GameMetadata } from "./game-metadata";
 export type { GameMetadataProps } from "./game-metadata";
-export { PlatformBadges } from "./platform-badges";
-export type { PlatformBadgesProps } from "./platform-badges";
+export {
+  getPlatformBadgeVariant,
+  getPlatformFamily,
+  PlatformBadges,
+} from "./platform-badges";
+export type { PlatformBadgesProps, PlatformFamily } from "./platform-badges";

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/index.ts
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/index.ts
@@ -1,2 +1,8 @@
 export { PlatformBadges } from "./platform-badges";
+export { PlatformBadgeItem } from "./platform-badge";
 export type { PlatformBadgesProps } from "./platform-badges.type";
+export {
+  getPlatformBadgeVariant,
+  getPlatformFamily,
+} from "./platform-badges.utility";
+export type { PlatformFamily } from "./platform-badges.utility";

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badge.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badge.tsx
@@ -1,10 +1,12 @@
 import { Badge } from "@/shared/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/shared/ui/tooltip";
-import { getPlatformIcon, abbreviatePlatformName, getPlatformBadgeVariant, getPlatformFamily } from "./platform-badges.utility";
+  abbreviatePlatformName,
+  getPlatformBadgeVariant,
+  getPlatformFamily,
+  getPlatformIcon,
+} from "./platform-badges.utility";
 
 export function PlatformBadgeItem({ name }: { name: string }) {
   const Icon = getPlatformIcon(name);

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badge.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/shared/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/shared/ui/tooltip";
+import { getPlatformIcon, abbreviatePlatformName, getPlatformBadgeVariant, getPlatformFamily } from "./platform-badges.utility";
+
+export function PlatformBadgeItem({ name }: { name: string }) {
+  const Icon = getPlatformIcon(name);
+  const abbreviated = abbreviatePlatformName(name);
+  const variant = getPlatformBadgeVariant(getPlatformFamily(name));
+
+  return (
+    <Tooltip key={name}>
+      <TooltipTrigger asChild>
+        <Badge
+          variant={variant}
+          className="gap-xs px-sm flex h-5 items-center rounded-md text-[11px]"
+        >
+          <Icon className="h-3 w-3" />
+          <span>{abbreviated}</span>
+        </Badge>
+      </TooltipTrigger>
+      {abbreviated !== name ? (
+        <TooltipContent side="top">
+          <p>{name}</p>
+        </TooltipContent>
+      ) : null}
+    </Tooltip>
+  );
+}

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.test.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.test.tsx
@@ -3,9 +3,20 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { PlatformBadges } from "./platform-badges";
 
+const badgeClassNameFor = (text: HTMLElement | null): string => {
+  // The Badge <div> carries the variant classes; the abbreviation/count text
+  // lives inside it. Walking to the nearest classed ancestor reaches the Badge.
+  // eslint-disable-next-line testing-library/no-node-access
+  const badge = text?.closest("[class]");
+  return badge?.className ?? "";
+};
+
 const elements = {
   queryChip: (label: string) => screen.queryByText(label),
   queryOverflowChip: () => screen.queryByText(/^\+\d+$/),
+  chipVariantClass: (label: string) =>
+    badgeClassNameFor(screen.queryByText(label)),
+  overflowVariantClass: () => badgeClassNameFor(screen.queryByText(/^\+\d+$/)),
 };
 
 describe("PlatformBadges", () => {
@@ -27,6 +38,52 @@ describe("PlatformBadges", () => {
 
     it("falls back to the full platform name as the chip label", () => {
       expect(elements.queryChip("Atari Jaguar")).not.toBeNull();
+    });
+  });
+
+  describe("given platforms across distinct families", () => {
+    beforeEach(() => {
+      render(
+        <PlatformBadges
+          platforms={["PlayStation 5", "Xbox Series X|S", "Sega Genesis"]}
+        />
+      );
+    });
+
+    it("colors the PlayStation chip with the playstation brand variant", () => {
+      expect(elements.chipVariantClass("PS5")).toContain("text-[#0070d1]");
+    });
+
+    it("colors the Xbox chip with the xbox brand variant", () => {
+      expect(elements.chipVariantClass("XSX")).toContain("text-[#107c10]");
+    });
+
+    it("keeps an unrecognised platform on the neutral subtle variant", () => {
+      const className = elements.chipVariantClass("Sega Genesis");
+      expect(className).toContain("text-muted-foreground");
+      expect(className).not.toContain("text-[#0070d1]");
+    });
+  });
+
+  describe("given an overflow of platforms", () => {
+    beforeEach(() => {
+      render(
+        <PlatformBadges
+          platforms={[
+            "PlayStation 5",
+            "Xbox Series X|S",
+            "Nintendo Switch",
+            "PC (Microsoft Windows)",
+            "Sega Genesis",
+          ]}
+        />
+      );
+    });
+
+    it("keeps the overflow '+N' chip on the neutral subtle variant", () => {
+      expect(elements.overflowVariantClass()).toContain(
+        "text-muted-foreground"
+      );
     });
   });
 

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.tsx
@@ -8,14 +8,10 @@ import {
 
 import type { PlatformBadgesProps } from "./platform-badges.type";
 import {
-  abbreviatePlatformName,
-  getPlatformIcon,
   MAX_VISIBLE_PLATFORMS,
 } from "./platform-badges.utility";
+import { PlatformBadgeItem } from "./platform-badge";
 
-// Display-only game-domain component. Mirrors savepoint-app
-// `shared/components/platform-badges.tsx`: abbreviated icon chips, max 4
-// visible, a "+N" overflow chip, tooltips for the full name on each.
 export function PlatformBadges({ platforms }: PlatformBadgesProps) {
   const visible = platforms.slice(0, MAX_VISIBLE_PLATFORMS);
   const remaining = platforms.slice(MAX_VISIBLE_PLATFORMS);
@@ -23,34 +19,13 @@ export function PlatformBadges({ platforms }: PlatformBadgesProps) {
   return (
     <TooltipProvider>
       <div className="gap-xs flex flex-wrap items-center">
-        {visible.map((name) => {
-          const Icon = getPlatformIcon(name);
-          const abbreviated = abbreviatePlatformName(name);
-          return (
-            <Tooltip key={name}>
-              <TooltipTrigger asChild>
-                <Badge
-                  variant="subtle"
-                  className="gap-xs px-sm flex h-5 items-center text-[11px]"
-                >
-                  <Icon className="h-3 w-3" />
-                  <span>{abbreviated}</span>
-                </Badge>
-              </TooltipTrigger>
-              {abbreviated !== name ? (
-                <TooltipContent side="top">
-                  <p>{name}</p>
-                </TooltipContent>
-              ) : null}
-            </Tooltip>
-          );
-        })}
+        {visible.map((name) => <PlatformBadgeItem name={name} key={name} />)}
         {remaining.length > 0 ? (
           <Tooltip>
             <TooltipTrigger asChild>
               <Badge
                 variant="subtle"
-                className="px-sm h-5 cursor-help text-[11px]"
+                className="px-sm h-5 cursor-help rounded-md text-[11px]"
               >
                 +{remaining.length}
               </Badge>

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.tsx
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.tsx
@@ -6,11 +6,9 @@ import {
   TooltipTrigger,
 } from "@/shared/ui/tooltip";
 
-import type { PlatformBadgesProps } from "./platform-badges.type";
-import {
-  MAX_VISIBLE_PLATFORMS,
-} from "./platform-badges.utility";
 import { PlatformBadgeItem } from "./platform-badge";
+import type { PlatformBadgesProps } from "./platform-badges.type";
+import { MAX_VISIBLE_PLATFORMS } from "./platform-badges.utility";
 
 export function PlatformBadges({ platforms }: PlatformBadgesProps) {
   const visible = platforms.slice(0, MAX_VISIBLE_PLATFORMS);
@@ -19,7 +17,9 @@ export function PlatformBadges({ platforms }: PlatformBadgesProps) {
   return (
     <TooltipProvider>
       <div className="gap-xs flex flex-wrap items-center">
-        {visible.map((name) => <PlatformBadgeItem name={name} key={name} />)}
+        {visible.map((name) => (
+          <PlatformBadgeItem name={name} key={name} />
+        ))}
         {remaining.length > 0 ? (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.utility.test.ts
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.utility.test.ts
@@ -11,6 +11,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   abbreviatePlatformName,
+  getPlatformBadgeVariant,
+  getPlatformFamily,
   getPlatformIcon,
 } from "./platform-badges.utility";
 
@@ -62,6 +64,104 @@ describe("getPlatformIcon", () => {
 
   it("returns TbDeviceGamepad2 for an unrecognised platform name", () => {
     expect(getPlatformIcon("Atari Jaguar")).toBe(TbDeviceGamepad2);
+  });
+});
+
+describe("getPlatformFamily", () => {
+  describe("playstation family", () => {
+    it("classifies 'PlayStation 5'", () => {
+      expect(getPlatformFamily("PlayStation 5")).toBe("playstation");
+    });
+
+    it("classifies 'PlayStation Vita'", () => {
+      expect(getPlatformFamily("PlayStation Vita")).toBe("playstation");
+    });
+
+    it("classifies a standalone 'PS' (matched by \\bps\\b)", () => {
+      expect(getPlatformFamily("PS")).toBe("playstation");
+    });
+  });
+
+  describe("xbox family", () => {
+    it("classifies 'Xbox Series X|S'", () => {
+      expect(getPlatformFamily("Xbox Series X|S")).toBe("xbox");
+    });
+  });
+
+  describe("nintendo family", () => {
+    it("classifies 'New Nintendo 3DS'", () => {
+      expect(getPlatformFamily("New Nintendo 3DS")).toBe("nintendo");
+    });
+
+    it("classifies 'Wii'", () => {
+      expect(getPlatformFamily("Wii")).toBe("nintendo");
+    });
+  });
+
+  describe("pc family", () => {
+    it("classifies 'PC (Microsoft Windows)'", () => {
+      expect(getPlatformFamily("PC (Microsoft Windows)")).toBe("pc");
+    });
+
+    it("classifies 'Steam Deck'", () => {
+      expect(getPlatformFamily("Steam Deck")).toBe("pc");
+    });
+
+    it("classifies 'Mac'", () => {
+      expect(getPlatformFamily("Mac")).toBe("pc");
+    });
+
+    it("classifies 'Linux'", () => {
+      expect(getPlatformFamily("Linux")).toBe("pc");
+    });
+
+    it("classifies a standalone 'PC' (matched by \\bpc\\b)", () => {
+      expect(getPlatformFamily("PC")).toBe("pc");
+    });
+  });
+
+  describe("other family (neutral)", () => {
+    it("classifies 'Sega Genesis'", () => {
+      expect(getPlatformFamily("Sega Genesis")).toBe("other");
+    });
+
+    it("classifies an unrecognised platform name", () => {
+      expect(getPlatformFamily("Atari Jaguar")).toBe("other");
+    });
+
+    it("classifies mobile 'iOS' as other, not pc", () => {
+      expect(getPlatformFamily("iOS")).toBe("other");
+    });
+
+    it("classifies mobile 'Android' as other, not pc", () => {
+      expect(getPlatformFamily("Android")).toBe("other");
+    });
+
+    it("classifies 'Windows Phone' as other despite containing 'windows'", () => {
+      expect(getPlatformFamily("Windows Phone")).toBe("other");
+    });
+  });
+});
+
+describe("getPlatformBadgeVariant", () => {
+  it("maps the playstation family to the 'playstation' variant", () => {
+    expect(getPlatformBadgeVariant("playstation")).toBe("playstation");
+  });
+
+  it("maps the xbox family to the 'xbox' variant", () => {
+    expect(getPlatformBadgeVariant("xbox")).toBe("xbox");
+  });
+
+  it("maps the nintendo family to the 'nintendo' variant", () => {
+    expect(getPlatformBadgeVariant("nintendo")).toBe("nintendo");
+  });
+
+  it("maps the pc family to the 'pc' variant", () => {
+    expect(getPlatformBadgeVariant("pc")).toBe("pc");
+  });
+
+  it("maps the other family to the neutral 'subtle' variant", () => {
+    expect(getPlatformBadgeVariant("other")).toBe("subtle");
   });
 });
 

--- a/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.utility.ts
+++ b/savepoint-tanstack/src/entities/game/ui/platform-badges/platform-badges.utility.ts
@@ -9,35 +9,88 @@ import {
 } from "react-icons/si";
 import { TbBrandWindows, TbDeviceGamepad2 } from "react-icons/tb";
 
+import type { BadgeProps } from "@/shared/ui/badge";
+
+export type PlatformFamily =
+  | "playstation"
+  | "xbox"
+  | "nintendo"
+  | "pc"
+  | "other";
+
+const isPlaystation = (lowerName: string): boolean =>
+  lowerName.includes("playstation") ||
+  lowerName.includes("vita") ||
+  /\bps\b/.test(lowerName);
+
+const isXbox = (lowerName: string): boolean => lowerName.includes("xbox");
+
+const NINTENDO_SUBSTRINGS = [
+  "switch",
+  "gamecube",
+  "super nintendo",
+  "game boy",
+  "gameboy",
+  "famicom",
+  "virtual boy",
+  "game & watch",
+  "satellaview",
+];
+
+// Short, ambiguous tokens (e.g. "nes" matches "geNESis") must match as whole
+// words so unrelated platforms like "Sega Genesis" do not classify as nintendo.
+const NINTENDO_WORD_TOKENS = [
+  "wii",
+  "n64",
+  "snes",
+  "nes",
+  "gba",
+  "gbc",
+  "3ds",
+  "ds",
+  "64dd",
+];
+
+const NINTENDO_WORD_PATTERN = new RegExp(
+  `\\b(${NINTENDO_WORD_TOKENS.join("|")})\\b`
+);
+
+const isNintendo = (lowerName: string): boolean =>
+  lowerName.includes("nintendo") ||
+  NINTENDO_SUBSTRINGS.some((keyword) => lowerName.includes(keyword)) ||
+  NINTENDO_WORD_PATTERN.test(lowerName);
+
+const MOBILE_KEYWORDS = ["windows phone", "windows mobile", "ios", "android"];
+
+const isMobile = (lowerName: string): boolean =>
+  MOBILE_KEYWORDS.some((keyword) => lowerName.includes(keyword));
+
+const isPc = (lowerName: string): boolean =>
+  lowerName.includes("windows") ||
+  lowerName.includes("mac") ||
+  lowerName.includes("macos") ||
+  lowerName.includes("linux") ||
+  lowerName.includes("steam") ||
+  lowerName.includes("dos") ||
+  /\bpc\b/.test(lowerName);
+
 // Mirrors savepoint-app `shared/lib/platform/get-platform-icon.tsx` so the
 // game-detail platform row renders identical brand glyphs across both apps.
+// Keyword cascade is shared with `getPlatformFamily` so a badge's glyph and
+// brand color always agree.
 export function getPlatformIcon(platformName: string): IconType {
   const lowerName = platformName.toLowerCase();
-  if (lowerName.includes("playstation") || /\bps\b/.test(lowerName)) {
+  if (isPlaystation(lowerName)) {
     return SiPlaystation;
   }
-  if (lowerName.includes("xbox")) {
+  if (isXbox(lowerName)) {
     return BsXbox;
   }
-  const nintendoPlatforms = [
-    "switch",
-    "wii",
-    "gamecube",
-    "nintendo 64",
-    "n64",
-    "super nintendo",
-    "snes",
-    "nes",
-    "game boy",
-    "gameboy",
-    "3ds",
-    "ds",
-  ];
-  if (
-    lowerName.includes("nintendo") ||
-    nintendoPlatforms.some((platform) => lowerName.includes(platform))
-  ) {
+  if (isNintendo(lowerName)) {
     return SiNintendo;
+  }
+  if (isMobile(lowerName)) {
+    return TbDeviceGamepad2;
   }
   if (lowerName.includes("windows")) {
     return TbBrandWindows;
@@ -55,6 +108,35 @@ export function getPlatformIcon(platformName: string): IconType {
     return TbDeviceGamepad2;
   }
   return TbDeviceGamepad2;
+}
+
+// Maps an IGDB platform name to its brand family. The cascade order and
+// keywords mirror `getPlatformIcon`; mobile is checked before pc so
+// "Windows Phone" classifies as `other`, not pc.
+export function getPlatformFamily(platformName: string): PlatformFamily {
+  const lowerName = platformName.toLowerCase();
+  if (isPlaystation(lowerName)) {
+    return "playstation";
+  }
+  if (isXbox(lowerName)) {
+    return "xbox";
+  }
+  if (isNintendo(lowerName)) {
+    return "nintendo";
+  }
+  if (isMobile(lowerName)) {
+    return "other";
+  }
+  if (isPc(lowerName)) {
+    return "pc";
+  }
+  return "other";
+}
+
+type BadgeVariant = NonNullable<BadgeProps["variant"]>;
+
+export function getPlatformBadgeVariant(family: PlatformFamily): BadgeVariant {
+  return family === "other" ? "subtle" : family;
 }
 
 // Mirrors savepoint-app `shared/components/platform-badges.tsx`

--- a/savepoint-tanstack/src/entities/journal-entry/api/create-journal-entry.server.ts
+++ b/savepoint-tanstack/src/entities/journal-entry/api/create-journal-entry.server.ts
@@ -11,6 +11,7 @@ export type CreateJournalEntryInput = {
   content: string;
   kind?: "QUICK" | "REFLECTION";
   gameId?: string | null;
+  playedMinutes?: number | null;
 };
 
 export async function createJournalEntry(
@@ -24,6 +25,7 @@ export async function createJournalEntry(
         content: input.content,
         kind: input.kind ?? "QUICK",
         gameId: input.gameId ?? null,
+        playedMinutes: input.playedMinutes ?? null,
       },
       include: { game: { select: JOURNAL_ENTRY_GAME_SELECT } },
     });

--- a/savepoint-tanstack/src/features/compose-journal-entry/api/create-journal-entry-fn.ts
+++ b/savepoint-tanstack/src/features/compose-journal-entry/api/create-journal-entry-fn.ts
@@ -12,11 +12,16 @@ import { requireUserId } from "@/entities/session/api/require-user-id";
  * - `kind` is optional; the entity layer defaults to `"QUICK"`.
  * - `gameId` is optional and may be explicitly `null` to mean "no game
  *   association". `z.string().min(1)` — never `cuid()` (Better-Auth ids).
+ * - `playedMinutes` is optional positive minutes for the logged session;
+ *   omitted → the entity persists `null`. Feeds total playtime + Your Pace
+ *   (spec 023 §2.3). `playSession` auto-derivation is intentionally deferred
+ *   so the handler stays a trivial pass-through (no worker split needed).
  */
 const CREATE_JOURNAL_ENTRY_INPUT = z.object({
   content: z.string().min(1, "Content is required").max(5000),
   kind: z.enum(["QUICK", "REFLECTION"]).optional(),
   gameId: z.string().min(1).nullable().optional(),
+  playedMinutes: z.number().int().positive().optional(),
 });
 
 export const createJournalEntryFn = createServerFn({ method: "POST" })

--- a/savepoint-tanstack/src/features/compose-journal-entry/ui/compose-journal-entry-dialog/compose-journal-entry-dialog.test.tsx
+++ b/savepoint-tanstack/src/features/compose-journal-entry/ui/compose-journal-entry-dialog/compose-journal-entry-dialog.test.tsx
@@ -30,6 +30,8 @@ const onOpenChange = vi.fn();
 
 const elements = {
   getContentTextarea: () => screen.getByRole("textbox", { name: "Content" }),
+  getMinutesInput: () =>
+    screen.getByRole("spinbutton", { name: "Time played (minutes)" }),
   getSubmitButton: () => screen.getByRole("button", { name: "Save" }),
   getCancelButton: () => screen.getByRole("button", { name: "Cancel" }),
   queryDialog: () => screen.queryByRole("dialog"),
@@ -38,6 +40,8 @@ const elements = {
 const actions = {
   typeContent: (text: string) =>
     userEvent.type(elements.getContentTextarea(), text),
+  typeMinutes: (value: string) =>
+    userEvent.type(elements.getMinutesInput(), value),
   submit: () => userEvent.click(elements.getSubmitButton()),
   cancel: () => userEvent.click(elements.getCancelButton()),
 };
@@ -65,6 +69,51 @@ describe("ComposeJournalEntryDialog", () => {
 
     it("renders a cancel button", () => {
       expect(elements.getCancelButton()).toBeDefined();
+    });
+
+    it("renders an optional time-played (minutes) field", () => {
+      expect(elements.getMinutesInput()).toBeDefined();
+    });
+  });
+
+  describe("given the user submits content with a time-played value", () => {
+    beforeEach(async () => {
+      render(
+        <ComposeJournalEntryDialog open={true} onOpenChange={onOpenChange} />
+      );
+
+      await actions.typeContent("Two solid hours tonight.");
+      await actions.typeMinutes("120");
+      await actions.submit();
+    });
+
+    it("calls createJournalEntryFn with the entered playedMinutes", () => {
+      expect(vi.mocked(createJournalEntryFn)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content: "Two solid hours tonight.",
+            playedMinutes: 120,
+          }),
+        })
+      );
+    });
+  });
+
+  describe("given the user submits content without a time-played value", () => {
+    beforeEach(async () => {
+      render(
+        <ComposeJournalEntryDialog open={true} onOpenChange={onOpenChange} />
+      );
+
+      await actions.typeContent("Quick note, no timing.");
+      await actions.submit();
+    });
+
+    it("calls createJournalEntryFn without a playedMinutes value", () => {
+      const call = vi.mocked(createJournalEntryFn).mock.calls[0]?.[0] as {
+        data: { playedMinutes?: number };
+      };
+      expect(call.data.playedMinutes).toBeUndefined();
     });
   });
 

--- a/savepoint-tanstack/src/features/compose-journal-entry/ui/compose-journal-entry-dialog/compose-journal-entry-dialog.tsx
+++ b/savepoint-tanstack/src/features/compose-journal-entry/ui/compose-journal-entry-dialog/compose-journal-entry-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 
 import type { ComposeJournalEntryDialogProps } from "./compose-journal-entry-dialog.type";
@@ -24,11 +25,18 @@ export function ComposeJournalEntryDialog({
 }: ComposeJournalEntryDialogProps) {
   const router = useRouter();
   const [content, setContent] = useState("");
+  const [minutes, setMinutes] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const trimmed = content.trim();
   const isEmpty = trimmed.length === 0;
+
+  const parsedMinutes = Number.parseInt(minutes, 10);
+  const playedMinutes =
+    Number.isInteger(parsedMinutes) && parsedMinutes > 0
+      ? parsedMinutes
+      : undefined;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -40,10 +48,12 @@ export function ComposeJournalEntryDialog({
           content: trimmed,
           kind: "QUICK",
           gameId: defaultGameId ?? null,
+          ...(playedMinutes !== undefined ? { playedMinutes } : {}),
         },
       });
       setError(null);
       setContent("");
+      setMinutes("");
       toast.success("Entry posted");
       await router.invalidate();
       onOpenChange(false);
@@ -79,6 +89,20 @@ export function ComposeJournalEntryDialog({
               value={content}
               onChange={(event) => setContent(event.target.value)}
               placeholder="What happened in your session?"
+            />
+          </label>
+
+          <label className="gap-xs flex flex-col text-sm">
+            <span className="text-muted-foreground">Time played (minutes)</span>
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              step={1}
+              aria-label="Time played (minutes)"
+              value={minutes}
+              onChange={(event) => setMinutes(event.target.value)}
+              placeholder="Optional"
             />
           </label>
 

--- a/savepoint-tanstack/src/features/game-detail/index.ts
+++ b/savepoint-tanstack/src/features/game-detail/index.ts
@@ -8,5 +8,7 @@ export {
 export {
   TimesToBeatSection,
   TimesToBeatSkeleton,
+  YourPacePanel,
   type TimesToBeatSectionProps,
+  type YourPacePanelProps,
 } from "./ui";

--- a/savepoint-tanstack/src/features/game-detail/ui/index.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/index.ts
@@ -1,3 +1,5 @@
 export { TimesToBeatSection } from "./times-to-beat-section";
 export type { TimesToBeatSectionProps } from "./times-to-beat-section";
 export { TimesToBeatSkeleton } from "./times-to-beat-skeleton";
+export { YourPacePanel } from "./your-pace-panel";
+export type { YourPacePanelProps } from "./your-pace-panel";

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.test.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.test.tsx
@@ -4,120 +4,168 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { TimesToBeatSection } from "./times-to-beat-section";
 
 const elements = {
-  getMainStoryValue: () => {
-    const dts = screen.getAllByRole("term");
-    const mainStoryIdx = Array.from(dts).findIndex(
-      (dt) => dt.textContent === "Main story"
-    );
-    const dds = screen.getAllByRole("definition");
-    return dds[mainStoryIdx];
-  },
-  getCompletionistValue: () => {
-    const dts = screen.getAllByRole("term");
-    const completionistIdx = Array.from(dts).findIndex(
-      (dt) => dt.textContent === "Completionist"
-    );
-    const dds = screen.getAllByRole("definition");
-    return dds[completionistIdx];
-  },
   getSection: () => screen.getByRole("region", { name: "Times to beat" }),
+  querySection: () => screen.queryByRole("region", { name: "Times to beat" }),
+  queryPace: () => screen.queryByRole("region", { name: "Your pace" }),
+  getYouMarker: () => screen.getByText(/^You ·/),
+  queryYouMarker: () => screen.queryByText(/^You ·/),
+  getMainStoryTick: () => screen.queryByText("Main story"),
+  getCompletionistTick: () => screen.queryByText("100%"),
+  getContext: () => screen.getByTestId("times-to-beat-context"),
+};
+
+const noPace = {
+  playtimeTotalMinutes: 0,
+  journalCount: 0,
+  recentSessionMinutes: [],
 };
 
 describe("TimesToBeatSection", () => {
-  describe("given both mainStory and completionist are provided as seconds", () => {
+  describe("given a benchmark with both main-story and completionist plus viewer hours", () => {
     beforeEach(() => {
+      // mainStory 36000s = 10h, completionist 72000s = 20h, viewer 720min = 12h
       render(
         <TimesToBeatSection
           timesToBeat={{ mainStory: 36000, completionist: 72000 }}
+          playtimeTotalMinutes={720}
+          journalCount={3}
+          recentSessionMinutes={[120, 240, 360]}
         />
       );
     });
 
-    it("renders the section heading", () => {
+    it("renders the times-to-beat section (benchmark mode)", () => {
       expect(elements.getSection()).toBeDefined();
     });
 
-    it("formats mainStory seconds to decimal hours", () => {
-      // 36000 seconds = 10.0 hours
-      expect(elements.getMainStoryValue()?.textContent).toBe("10.0 h");
+    it("does not render the Your Pace fallback", () => {
+      expect(elements.queryPace()).toBeNull();
     });
 
-    it("formats completionist seconds to decimal hours", () => {
-      // 72000 seconds = 20.0 hours
-      expect(elements.getCompletionistValue()?.textContent).toBe("20.0 h");
+    it("marks the viewer's hours with an accent 'You' marker", () => {
+      expect(elements.getYouMarker().textContent).toContain("12h");
+    });
+
+    it("renders the main-story benchmark tick", () => {
+      expect(elements.getMainStoryTick()).not.toBeNull();
+    });
+
+    it("renders the 100% benchmark tick", () => {
+      expect(elements.getCompletionistTick()).not.toBeNull();
+    });
+
+    it("puts the viewer's progress in context relative to the main story", () => {
+      // 12h - 10h = 2h past the main story; 20h - 12h = 8h left to 100%
+      const text = elements.getContext().textContent ?? "";
+      expect(text).toContain("2h past");
+      expect(text).toContain("8h");
     });
   });
 
-  describe("given fractional hours (rounding)", () => {
+  describe("given the viewer is short of the main story", () => {
     beforeEach(() => {
+      // mainStory 36000s = 10h, viewer 180min = 3h
       render(
         <TimesToBeatSection
-          timesToBeat={{ mainStory: 5400, completionist: 3700 }}
+          timesToBeat={{ mainStory: 36000, completionist: 72000 }}
+          playtimeTotalMinutes={180}
+          journalCount={1}
+          recentSessionMinutes={[180]}
         />
       );
     });
 
-    it("rounds mainStory to one decimal place", () => {
-      // 5400 / 3600 = 1.5 h
-      expect(elements.getMainStoryValue()?.textContent).toBe("1.5 h");
-    });
-
-    it("rounds completionist to one decimal place", () => {
-      // 3700 / 3600 = 1.0277... → rounds to 1.0 h
-      expect(elements.getCompletionistValue()?.textContent).toBe("1.0 h");
+    it("phrases the context as hours from the main story", () => {
+      const text = elements.getContext().textContent ?? "";
+      expect(text).toContain("7h from");
     });
   });
 
-  describe("given mainStory is null (no data)", () => {
+  describe("given only the main-story benchmark is present", () => {
     beforeEach(() => {
       render(
         <TimesToBeatSection
-          timesToBeat={{ mainStory: null, completionist: 14400 }}
+          timesToBeat={{ mainStory: 36000, completionist: null }}
+          {...noPace}
         />
       );
     });
 
-    it("renders the em-dash for the null main story value", () => {
-      expect(elements.getMainStoryValue()?.textContent).toBe("—");
+    it("renders the main-story tick", () => {
+      expect(elements.getMainStoryTick()).not.toBeNull();
     });
 
-    it("still renders the completionist value", () => {
-      // 14400 / 3600 = 4.0 h
-      expect(elements.getCompletionistValue()?.textContent).toBe("4.0 h");
+    it("omits the 100% tick", () => {
+      expect(elements.getCompletionistTick()).toBeNull();
     });
   });
 
-  describe("given completionist is null (no data)", () => {
+  describe("given only the completionist benchmark is present", () => {
     beforeEach(() => {
       render(
         <TimesToBeatSection
-          timesToBeat={{ mainStory: 10800, completionist: null }}
+          timesToBeat={{ mainStory: null, completionist: 72000 }}
+          {...noPace}
         />
       );
     });
 
-    it("renders the em-dash for the null completionist value", () => {
-      expect(elements.getCompletionistValue()?.textContent).toBe("—");
+    it("renders the 100% tick", () => {
+      expect(elements.getCompletionistTick()).not.toBeNull();
     });
 
-    it("still renders the main story value", () => {
-      // 10800 / 3600 = 3.0 h
-      expect(elements.getMainStoryValue()?.textContent).toBe("3.0 h");
+    it("omits the main-story tick", () => {
+      expect(elements.getMainStoryTick()).toBeNull();
     });
   });
 
-  describe("given both values are null", () => {
+  describe("given a benchmark object whose fields are both null", () => {
     beforeEach(() => {
       render(
         <TimesToBeatSection
           timesToBeat={{ mainStory: null, completionist: null }}
+          {...noPace}
         />
       );
     });
 
-    it("renders em-dash for both fields", () => {
-      expect(elements.getMainStoryValue()?.textContent).toBe("—");
-      expect(elements.getCompletionistValue()?.textContent).toBe("—");
+    it("still renders the benchmark section rather than the pace fallback", () => {
+      expect(elements.getSection()).toBeDefined();
+      expect(elements.queryPace()).toBeNull();
+    });
+
+    it("renders neither benchmark tick", () => {
+      expect(elements.getMainStoryTick()).toBeNull();
+      expect(elements.getCompletionistTick()).toBeNull();
+    });
+
+    it("renders an empty context sentence rather than fabricating a benchmark", () => {
+      expect(elements.getContext().textContent).toBe("");
+    });
+  });
+
+  describe("given no benchmark (null)", () => {
+    beforeEach(() => {
+      render(
+        <TimesToBeatSection
+          timesToBeat={null}
+          playtimeTotalMinutes={600}
+          journalCount={4}
+          recentSessionMinutes={[60, 120, 180, 240]}
+        />
+      );
+    });
+
+    it("falls back to the Your Pace panel", () => {
+      expect(elements.queryPace()).not.toBeNull();
+    });
+
+    it("does not render the benchmark section", () => {
+      expect(elements.querySection()).toBeNull();
+    });
+
+    it("does not render a 'You' benchmark marker", () => {
+      expect(elements.queryYouMarker()).toBeNull();
     });
   });
 });

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.test.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.test.tsx
@@ -17,6 +17,7 @@ const elements = {
 const noPace = {
   playtimeTotalMinutes: 0,
   journalCount: 0,
+  playtimeSessionCount: 0,
   recentSessionMinutes: [],
 };
 
@@ -29,6 +30,7 @@ describe("TimesToBeatSection", () => {
           timesToBeat={{ mainStory: 36000, completionist: 72000 }}
           playtimeTotalMinutes={720}
           journalCount={3}
+          playtimeSessionCount={3}
           recentSessionMinutes={[120, 240, 360]}
         />
       );
@@ -70,6 +72,7 @@ describe("TimesToBeatSection", () => {
           timesToBeat={{ mainStory: 36000, completionist: 72000 }}
           playtimeTotalMinutes={180}
           journalCount={1}
+          playtimeSessionCount={1}
           recentSessionMinutes={[180]}
         />
       );
@@ -151,6 +154,7 @@ describe("TimesToBeatSection", () => {
           timesToBeat={null}
           playtimeTotalMinutes={600}
           journalCount={4}
+          playtimeSessionCount={4}
           recentSessionMinutes={[60, 120, 180, 240]}
         />
       );

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.tsx
@@ -19,6 +19,7 @@ export function TimesToBeatSection({
   timesToBeat,
   playtimeTotalMinutes,
   journalCount,
+  playtimeSessionCount,
   recentSessionMinutes,
 }: TimesToBeatSectionProps) {
   if (timesToBeat === null) {
@@ -26,6 +27,7 @@ export function TimesToBeatSection({
       <YourPacePanel
         journalCount={journalCount}
         playtimeTotalMinutes={playtimeTotalMinutes}
+        playtimeSessionCount={playtimeSessionCount}
         recentSessionMinutes={recentSessionMinutes}
       />
     );

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.tsx
@@ -1,14 +1,68 @@
+import { YourPacePanel } from "@/features/game-detail/ui/your-pace-panel";
+
 import type { TimesToBeatSectionProps } from "./times-to-beat-section.type";
 
 const SECONDS_PER_HOUR = 3600;
+const MINUTES_PER_HOUR = 60;
 
-function formatHours(seconds: number | null): string {
-  if (seconds === null) return "—";
-  const hours = seconds / SECONDS_PER_HOUR;
-  return `${(Math.round(hours * 10) / 10).toFixed(1)} h`;
+function secondsToHours(seconds: number): number {
+  return Math.round((seconds / SECONDS_PER_HOUR) * 10) / 10;
 }
 
-export function TimesToBeatSection({ timesToBeat }: TimesToBeatSectionProps) {
+function minutesToHours(minutes: number): number {
+  return Math.round((minutes / MINUTES_PER_HOUR) * 10) / 10;
+}
+
+type BeatTick = { key: string; label: string; hours: number; anchor: string };
+
+export function TimesToBeatSection({
+  timesToBeat,
+  playtimeTotalMinutes,
+  journalCount,
+  recentSessionMinutes,
+}: TimesToBeatSectionProps) {
+  if (timesToBeat === null) {
+    return (
+      <YourPacePanel
+        journalCount={journalCount}
+        playtimeTotalMinutes={playtimeTotalMinutes}
+        recentSessionMinutes={recentSessionMinutes}
+      />
+    );
+  }
+
+  const youHours = minutesToHours(playtimeTotalMinutes);
+  const mainHours =
+    timesToBeat.mainStory === null
+      ? null
+      : secondsToHours(timesToBeat.mainStory);
+  const compHours =
+    timesToBeat.completionist === null
+      ? null
+      : secondsToHours(timesToBeat.completionist);
+
+  const ticks: BeatTick[] = [];
+  if (mainHours !== null) {
+    ticks.push({
+      key: "main",
+      label: "Main story",
+      hours: mainHours,
+      anchor: "-50%",
+    });
+  }
+  if (compHours !== null) {
+    ticks.push({
+      key: "completionist",
+      label: "100%",
+      hours: compHours,
+      anchor: "-100%",
+    });
+  }
+
+  const scaleMax = Math.max(youHours, compHours ?? 0, mainHours ?? 0, 1) * 1.1;
+  const percent = (hours: number) =>
+    `${Math.min(100, (hours / scaleMax) * 100)}%`;
+
   return (
     <section
       aria-labelledby="times-to-beat-heading"
@@ -17,12 +71,103 @@ export function TimesToBeatSection({ timesToBeat }: TimesToBeatSectionProps) {
       <h2 id="times-to-beat-heading" className="text-h3">
         Times to beat
       </h2>
-      <dl className="grid grid-cols-2 gap-2 text-sm">
-        <dt className="text-muted-foreground">Main story</dt>
-        <dd>{formatHours(timesToBeat.mainStory)}</dd>
-        <dt className="text-muted-foreground">Completionist</dt>
-        <dd>{formatHours(timesToBeat.completionist)}</dd>
-      </dl>
+
+      <div className="pt-6">
+        <div className="relative h-24">
+          <div
+            className="absolute top-0 z-10 flex -translate-x-1/2 flex-col items-center"
+            style={{ left: percent(youHours) }}
+          >
+            <span className="text-primary text-caption mb-1 tracking-wider whitespace-nowrap uppercase">
+              You · {youHours}h
+            </span>
+            <span className="bg-primary ring-primary/20 h-3 w-3 rounded-full ring-4" />
+          </div>
+
+          <div className="bg-muted-foreground/15 absolute top-10 right-0 left-0 h-1.5 rounded-full" />
+          <div
+            className="bg-primary absolute top-10 left-0 h-1.5 rounded-full"
+            style={{ width: percent(youHours) }}
+          />
+          <div
+            className="bg-primary/55 absolute top-6 h-4 w-0.5 -translate-x-1/2"
+            style={{ left: percent(youHours) }}
+          />
+
+          {ticks.map((tick) => (
+            <div
+              key={tick.key}
+              className="absolute top-8 flex flex-col items-center"
+              style={{
+                left: percent(tick.hours),
+                transform: `translateX(${tick.anchor})`,
+              }}
+            >
+              <span className="bg-muted-foreground/45 h-4 w-0.5" />
+              <span className="text-muted-foreground text-caption mt-1.5 tracking-wider whitespace-nowrap uppercase">
+                {tick.label}
+              </span>
+              <span className="text-foreground font-mono text-xs font-semibold">
+                {tick.hours}h
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p
+        data-testid="times-to-beat-context"
+        className="text-foreground text-sm"
+      >
+        <BeatContext
+          youHours={youHours}
+          mainHours={mainHours}
+          compHours={compHours}
+        />
+      </p>
     </section>
   );
+}
+
+function BeatContext({
+  youHours,
+  mainHours,
+  compHours,
+}: {
+  youHours: number;
+  mainHours: number | null;
+  compHours: number | null;
+}) {
+  if (mainHours !== null) {
+    const delta = Math.round((youHours - mainHours) * 10) / 10;
+    const direction = delta >= 0 ? "past" : "from";
+    const remaining =
+      compHours === null
+        ? null
+        : Math.max(0, Math.round((compHours - youHours) * 10) / 10);
+    return (
+      <>
+        You're{" "}
+        <strong className="text-primary">
+          {Math.abs(delta)}h {direction}
+        </strong>{" "}
+        the main story
+        {remaining === null
+          ? "."
+          : ` — about ${remaining}h of the long road left to 100%.`}
+      </>
+    );
+  }
+
+  if (compHours !== null) {
+    const remaining = Math.max(0, Math.round((compHours - youHours) * 10) / 10);
+    return (
+      <>
+        About <strong className="text-primary">{remaining}h</strong> left on the
+        road to 100%.
+      </>
+    );
+  }
+
+  return null;
 }

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.type.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.type.ts
@@ -1,5 +1,12 @@
 import type { TimesToBeat } from "@/entities/game/api";
 
 export type TimesToBeatSectionProps = {
-  timesToBeat: TimesToBeat;
+  /** Community benchmark in seconds, or `null` when no estimate exists. */
+  timesToBeat: TimesToBeat | null;
+  /** Viewer's total logged minutes for this game. */
+  playtimeTotalMinutes: number;
+  /** Viewer's journal-entry count for this game. */
+  journalCount: number;
+  /** Viewer's recent non-null per-session minutes, oldest→newest. */
+  recentSessionMinutes: number[];
 };

--- a/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.type.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/times-to-beat-section/times-to-beat-section.type.ts
@@ -7,6 +7,8 @@ export type TimesToBeatSectionProps = {
   playtimeTotalMinutes: number;
   /** Viewer's journal-entry count for this game. */
   journalCount: number;
+  /** Viewer's count of sessions carrying logged minutes. */
+  playtimeSessionCount: number;
   /** Viewer's recent non-null per-session minutes, oldest→newest. */
   recentSessionMinutes: number[];
 };

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/index.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/index.ts
@@ -1,0 +1,2 @@
+export { YourPacePanel } from "./your-pace-panel";
+export type { YourPacePanelProps } from "./your-pace-panel.type";

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.test.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.test.tsx
@@ -17,6 +17,7 @@ describe("YourPacePanel", () => {
         <YourPacePanel
           journalCount={4}
           playtimeTotalMinutes={600}
+          playtimeSessionCount={4}
           recentSessionMinutes={[60, 120, 180, 240]}
         />
       );
@@ -53,12 +54,38 @@ describe("YourPacePanel", () => {
     });
   });
 
+  describe("given some entries carry no recorded minutes", () => {
+    beforeEach(() => {
+      // 4 journal entries, but only 2 logged minutes (600 total).
+      render(
+        <YourPacePanel
+          journalCount={4}
+          playtimeTotalMinutes={600}
+          playtimeSessionCount={2}
+          recentSessionMinutes={[240, 360]}
+        />
+      );
+    });
+
+    it("counts every journal entry under Sessions", () => {
+      expect(within(elements.getStat("Sessions")).getByText("4")).toBeDefined();
+    });
+
+    it("averages only over sessions that logged minutes, not all entries", () => {
+      // 600min / 2 contributing sessions = 5h — not 600 / 4 = 2.5h.
+      expect(
+        within(elements.getStat("Avg session")).getByText("5h")
+      ).toBeDefined();
+    });
+  });
+
   describe("given no recorded session minutes", () => {
     beforeEach(() => {
       render(
         <YourPacePanel
           journalCount={2}
           playtimeTotalMinutes={0}
+          playtimeSessionCount={0}
           recentSessionMinutes={[]}
         />
       );
@@ -79,6 +106,7 @@ describe("YourPacePanel", () => {
         <YourPacePanel
           journalCount={0}
           playtimeTotalMinutes={0}
+          playtimeSessionCount={0}
           recentSessionMinutes={[]}
         />
       );

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.test.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { YourPacePanel } from "./your-pace-panel";
+
+const elements = {
+  getSection: () => screen.getByRole("region", { name: "Your pace" }),
+  getStat: (label: string) => screen.getByRole("group", { name: label }),
+  getBars: () => screen.getAllByRole("img", { name: /^Session \d/ }),
+  queryBars: () => screen.queryAllByRole("img", { name: /^Session \d/ }),
+};
+
+describe("YourPacePanel", () => {
+  describe("given several recorded sessions", () => {
+    beforeEach(() => {
+      render(
+        <YourPacePanel
+          journalCount={4}
+          playtimeTotalMinutes={600}
+          recentSessionMinutes={[60, 120, 180, 240]}
+        />
+      );
+    });
+
+    it("renders the section", () => {
+      expect(elements.getSection()).toBeDefined();
+    });
+
+    it("shows the sessions count", () => {
+      expect(within(elements.getStat("Sessions")).getByText("4")).toBeDefined();
+    });
+
+    it("shows the total logged hours", () => {
+      // 600 minutes = 10h
+      expect(within(elements.getStat("Total")).getByText("10h")).toBeDefined();
+    });
+
+    it("shows the average per session", () => {
+      // 10h / 4 sessions = 2.5h
+      expect(
+        within(elements.getStat("Avg session")).getByText("2.5h")
+      ).toBeDefined();
+    });
+
+    it("renders one recent-session bar per recorded session", () => {
+      expect(elements.getBars()).toHaveLength(4);
+    });
+
+    it("orders the recent-session bars oldest to newest", () => {
+      const bars = elements.getBars();
+      expect(bars[0]).toHaveAttribute("aria-label", "Session 1: 1h");
+      expect(bars[3]).toHaveAttribute("aria-label", "Session 4: 4h");
+    });
+  });
+
+  describe("given no recorded session minutes", () => {
+    beforeEach(() => {
+      render(
+        <YourPacePanel
+          journalCount={2}
+          playtimeTotalMinutes={0}
+          recentSessionMinutes={[]}
+        />
+      );
+    });
+
+    it("still shows the sessions count", () => {
+      expect(within(elements.getStat("Sessions")).getByText("2")).toBeDefined();
+    });
+
+    it("renders no recent-session bars", () => {
+      expect(elements.queryBars()).toHaveLength(0);
+    });
+  });
+
+  describe("given zero sessions", () => {
+    beforeEach(() => {
+      render(
+        <YourPacePanel
+          journalCount={0}
+          playtimeTotalMinutes={0}
+          recentSessionMinutes={[]}
+        />
+      );
+    });
+
+    it("shows a zero average rather than dividing by zero", () => {
+      expect(
+        within(elements.getStat("Avg session")).getByText("0h")
+      ).toBeDefined();
+    });
+  });
+});

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.tsx
@@ -1,0 +1,86 @@
+import type { YourPacePanelProps } from "./your-pace-panel.type";
+
+const MINUTES_PER_HOUR = 60;
+const RECENT_BAR_LIMIT = 9;
+
+function toHours(minutes: number): number {
+  return Math.round(minutes / MINUTES_PER_HOUR);
+}
+
+function toAverageHours(totalMinutes: number, sessions: number): number {
+  if (sessions <= 0) return 0;
+  return Math.round((totalMinutes / sessions / MINUTES_PER_HOUR) * 10) / 10;
+}
+
+export function YourPacePanel({
+  journalCount,
+  playtimeTotalMinutes,
+  recentSessionMinutes,
+}: YourPacePanelProps) {
+  const totalHours = toHours(playtimeTotalMinutes);
+  const averageHours = toAverageHours(playtimeTotalMinutes, journalCount);
+  const recent = recentSessionMinutes.slice(-RECENT_BAR_LIMIT);
+  const maxMinutes = Math.max(...recent, 1);
+
+  return (
+    <section
+      aria-labelledby="your-pace-heading"
+      className="gap-md flex flex-col"
+    >
+      <h2 id="your-pace-heading" className="text-h3">
+        Your pace
+      </h2>
+
+      <div className="gap-lg flex">
+        <PaceStat label="Avg session" value={`${averageHours}h`} />
+        <PaceStat label="Total" value={`${totalHours}h`} />
+        <PaceStat label="Sessions" value={String(journalCount)} />
+      </div>
+
+      {recent.length > 0 ? (
+        <>
+          <div className="flex h-20 items-end gap-1.5">
+            {recent.map((minutes, index) => {
+              const hours = toHours(minutes);
+              return (
+                <div
+                  key={index}
+                  role="img"
+                  aria-label={`Session ${index + 1}: ${hours}h`}
+                  className="bg-primary flex-1 rounded-sm"
+                  style={{
+                    height: `${Math.max(10, (minutes / maxMinutes) * 100)}%`,
+                    opacity:
+                      0.45 + 0.55 * (index / Math.max(1, recent.length - 1)),
+                  }}
+                />
+              );
+            })}
+          </div>
+          <div className="text-muted-foreground text-caption flex justify-between tracking-wider uppercase">
+            <span>Earlier</span>
+            <span>Latest</span>
+          </div>
+        </>
+      ) : null}
+
+      <p className="text-muted-foreground text-sm italic">
+        No community time-to-beat estimate for this release yet — so here's your
+        own rhythm instead.
+      </p>
+    </section>
+  );
+}
+
+function PaceStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1" role="group" aria-label={label}>
+      <span className="text-muted-foreground text-caption tracking-wider uppercase">
+        {label}
+      </span>
+      <span className="text-foreground font-mono text-xl font-bold tabular-nums">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.tsx
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.tsx
@@ -15,10 +15,14 @@ function toAverageHours(totalMinutes: number, sessions: number): number {
 export function YourPacePanel({
   journalCount,
   playtimeTotalMinutes,
+  playtimeSessionCount,
   recentSessionMinutes,
 }: YourPacePanelProps) {
   const totalHours = toHours(playtimeTotalMinutes);
-  const averageHours = toAverageHours(playtimeTotalMinutes, journalCount);
+  const averageHours = toAverageHours(
+    playtimeTotalMinutes,
+    playtimeSessionCount
+  );
   const recent = recentSessionMinutes.slice(-RECENT_BAR_LIMIT);
   const maxMinutes = Math.max(...recent, 1);
 

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.type.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.type.ts
@@ -1,6 +1,8 @@
 export type YourPacePanelProps = {
   journalCount: number;
   playtimeTotalMinutes: number;
+  /** Sessions that actually contributed minutes — the denominator for "Avg session". */
+  playtimeSessionCount: number;
   /** Recent non-null per-session minutes, oldest→newest. */
   recentSessionMinutes: number[];
 };

--- a/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.type.ts
+++ b/savepoint-tanstack/src/features/game-detail/ui/your-pace-panel/your-pace-panel.type.ts
@@ -1,0 +1,6 @@
+export type YourPacePanelProps = {
+  journalCount: number;
+  playtimeTotalMinutes: number;
+  /** Recent non-null per-session minutes, oldest→newest. */
+  recentSessionMinutes: number[];
+};

--- a/savepoint-tanstack/src/routes/-games.$slug.test.tsx
+++ b/savepoint-tanstack/src/routes/-games.$slug.test.tsx
@@ -58,10 +58,13 @@ vi.mock("@/features/game-detail/ui", () => ({
   TimesToBeatSection: ({
     timesToBeat,
   }: {
-    timesToBeat: { mainStory: number | null; completionist: number | null };
+    timesToBeat: {
+      mainStory: number | null;
+      completionist: number | null;
+    } | null;
   }) => (
     <div data-testid="times-to-beat-section">
-      ms:{timesToBeat.mainStory ?? "null"}
+      ms:{timesToBeat?.mainStory ?? "null"}
     </div>
   ),
   TimesToBeatSkeleton: () => <div data-testid="times-to-beat-skeleton" />,
@@ -98,9 +101,11 @@ const buildView = (
       name: "Celeste",
       slug: "celeste",
     },
-    relatedGames: [],
     libraryEntry: null,
     journalTeaser: [],
+    journalCount: 0,
+    playtimeTotalMinutes: 0,
+    recentSessionMinutes: [],
   },
   viewerUserId: null,
   ...overrides,

--- a/savepoint-tanstack/src/routes/-games.$slug.test.tsx
+++ b/savepoint-tanstack/src/routes/-games.$slug.test.tsx
@@ -105,6 +105,7 @@ const buildView = (
     journalTeaser: [],
     journalCount: 0,
     playtimeTotalMinutes: 0,
+    playtimeSessionCount: 0,
     recentSessionMinutes: [],
   },
   viewerUserId: null,

--- a/savepoint-tanstack/src/routes/games.$slug.tsx
+++ b/savepoint-tanstack/src/routes/games.$slug.tsx
@@ -17,6 +17,7 @@ import {
   TimesToBeatSkeleton,
 } from "@/features/game-detail/ui";
 import { AppError } from "@/shared/lib/errors";
+import { Card } from "@/shared/ui/card";
 import { GameCard } from "@/widgets/game-card";
 import { GameDetail } from "@/widgets/game-detail";
 
@@ -46,21 +47,34 @@ function GameDetailRoute() {
           }
         >
           <Suspense fallback={<TimesToBeatSkeleton />}>
-            <TimesToBeatSlot igdbId={igdbId} />
+            <TimesToBeatSlot
+              igdbId={igdbId}
+              playtimeTotalMinutes={data.playtimeTotalMinutes}
+              journalCount={data.journalCount}
+              recentSessionMinutes={data.recentSessionMinutes}
+            />
           </Suspense>
         </SectionErrorBoundary>
       }
       relatedGamesSlot={
         <SectionErrorBoundary
           fallback={
-            <SectionErrorMessage
-              headingId="related-games-heading"
-              heading="Related games"
-              message="Couldn't load related games"
-            />
+            <Card variant="flat" className="gap-md p-xl flex flex-col">
+              <SectionErrorMessage
+                headingId="related-games-heading"
+                heading="Related games"
+                message="Couldn't load related games"
+              />
+            </Card>
           }
         >
-          <Suspense fallback={<RelatedGamesSkeleton />}>
+          <Suspense
+            fallback={
+              <Card variant="flat" className="gap-md p-xl flex flex-col">
+                <RelatedGamesSkeleton />
+              </Card>
+            }
+          >
             <RelatedGamesSlot igdbId={igdbId} />
           </Suspense>
         </SectionErrorBoundary>
@@ -69,13 +83,29 @@ function GameDetailRoute() {
   );
 }
 
-function TimesToBeatSlot({ igdbId }: { igdbId: number }) {
+function TimesToBeatSlot({
+  igdbId,
+  playtimeTotalMinutes,
+  journalCount,
+  recentSessionMinutes,
+}: {
+  igdbId: number;
+  playtimeTotalMinutes: number;
+  journalCount: number;
+  recentSessionMinutes: number[];
+}) {
   const { data: timesToBeat } = useSuspenseQuery({
     queryKey: ["times-to-beat", igdbId],
     queryFn: () => getTimesToBeatForGameFn({ data: { igdbId } }),
   });
-  if (timesToBeat === null) return null;
-  return <TimesToBeatSection timesToBeat={timesToBeat} />;
+  return (
+    <TimesToBeatSection
+      timesToBeat={timesToBeat}
+      playtimeTotalMinutes={playtimeTotalMinutes}
+      journalCount={journalCount}
+      recentSessionMinutes={recentSessionMinutes}
+    />
+  );
 }
 
 function RelatedGamesSlot({ igdbId }: { igdbId: number }) {
@@ -93,27 +123,29 @@ function RelatedGamesSections({
   sections: RelatedCollectionSection[];
 }) {
   return (
-    <section
-      aria-labelledby="related-games-heading"
-      className="gap-md flex flex-col"
-    >
-      <h2 id="related-games-heading" className="text-h3">
-        Related games
-      </h2>
-      <RelatedGamesTabs
-        sections={sections}
-        renderGame={(game) => (
-          <GameCard
-            game={{
-              slug: game.slug,
-              title: game.title,
-              coverImageId: game.coverImageId,
-            }}
-            density="minimal"
-          />
-        )}
-      />
-    </section>
+    <Card variant="flat" className="gap-md p-xl flex flex-col">
+      <section
+        aria-labelledby="related-games-heading"
+        className="gap-md flex flex-col"
+      >
+        <h2 id="related-games-heading" className="text-h3">
+          Related games
+        </h2>
+        <RelatedGamesTabs
+          sections={sections}
+          renderGame={(game) => (
+            <GameCard
+              game={{
+                slug: game.slug,
+                title: game.title,
+                coverImageId: game.coverImageId,
+              }}
+              density="minimal"
+            />
+          )}
+        />
+      </section>
+    </Card>
   );
 }
 

--- a/savepoint-tanstack/src/routes/games.$slug.tsx
+++ b/savepoint-tanstack/src/routes/games.$slug.tsx
@@ -51,6 +51,7 @@ function GameDetailRoute() {
               igdbId={igdbId}
               playtimeTotalMinutes={data.playtimeTotalMinutes}
               journalCount={data.journalCount}
+              playtimeSessionCount={data.playtimeSessionCount}
               recentSessionMinutes={data.recentSessionMinutes}
             />
           </Suspense>
@@ -87,11 +88,13 @@ function TimesToBeatSlot({
   igdbId,
   playtimeTotalMinutes,
   journalCount,
+  playtimeSessionCount,
   recentSessionMinutes,
 }: {
   igdbId: number;
   playtimeTotalMinutes: number;
   journalCount: number;
+  playtimeSessionCount: number;
   recentSessionMinutes: number[];
 }) {
   const { data: timesToBeat } = useSuspenseQuery({
@@ -103,6 +106,7 @@ function TimesToBeatSlot({
       timesToBeat={timesToBeat}
       playtimeTotalMinutes={playtimeTotalMinutes}
       journalCount={journalCount}
+      playtimeSessionCount={playtimeSessionCount}
       recentSessionMinutes={recentSessionMinutes}
     />
   );

--- a/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.test.tsx
+++ b/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImageLightbox } from "./image-lightbox";
+
+const images = [
+  { src: "https://example.com/shot-1.jpg", alt: "Screenshot 1" },
+  { src: "https://example.com/shot-2.jpg", alt: "Screenshot 2" },
+  { src: "https://example.com/shot-3.jpg", alt: "Screenshot 3" },
+];
+
+const onOpenChange = vi.fn();
+const onIndexChange = vi.fn();
+
+const elements = {
+  getCurrentImage: () =>
+    screen.getByRole("img", { name: "Screenshot 2" }) as HTMLImageElement,
+  queryCurrentImage: () => screen.queryByRole("img", { name: "Screenshot 2" }),
+  getNext: () => screen.getByRole("button", { name: "Next screenshot" }),
+  getPrev: () => screen.getByRole("button", { name: "Previous screenshot" }),
+  getClose: () => screen.getByRole("button", { name: "Close" }),
+  getThumbnail: (n: number) =>
+    screen.getByRole("button", { name: `View screenshot ${n}` }),
+};
+
+const actions = {
+  clickNext: () => userEvent.click(elements.getNext()),
+  clickPrev: () => userEvent.click(elements.getPrev()),
+  clickClose: () => userEvent.click(elements.getClose()),
+  pressRight: () => userEvent.keyboard("{ArrowRight}"),
+  pressLeft: () => userEvent.keyboard("{ArrowLeft}"),
+  pressEscape: () => userEvent.keyboard("{Escape}"),
+  jumpToThumbnail: (n: number) => userEvent.click(elements.getThumbnail(n)),
+};
+
+describe("ImageLightbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given it is open at index 1", () => {
+    beforeEach(() => {
+      render(
+        <ImageLightbox
+          images={images}
+          open
+          index={1}
+          onOpenChange={onOpenChange}
+          onIndexChange={onIndexChange}
+        />
+      );
+    });
+
+    it("renders the current image with an accessible alt", () => {
+      expect(elements.queryCurrentImage()).not.toBeNull();
+      expect(elements.getCurrentImage().src).toBe(
+        "https://example.com/shot-2.jpg"
+      );
+    });
+
+    it("advances to the next index when Next is clicked", async () => {
+      await actions.clickNext();
+      expect(onIndexChange).toHaveBeenCalledWith(2);
+    });
+
+    it("goes to the previous index when Previous is clicked", async () => {
+      await actions.clickPrev();
+      expect(onIndexChange).toHaveBeenCalledWith(0);
+    });
+
+    it("advances on the ArrowRight key", async () => {
+      await actions.pressRight();
+      expect(onIndexChange).toHaveBeenCalledWith(2);
+    });
+
+    it("goes back on the ArrowLeft key", async () => {
+      await actions.pressLeft();
+      expect(onIndexChange).toHaveBeenCalledWith(0);
+    });
+
+    it("jumps to a thumbnail when its strip button is clicked", async () => {
+      await actions.jumpToThumbnail(3);
+      expect(onIndexChange).toHaveBeenCalledWith(2);
+    });
+
+    it("closes on the Close button", async () => {
+      await actions.clickClose();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("closes on the Escape key", async () => {
+      await actions.pressEscape();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("given it is open at the last index", () => {
+    beforeEach(() => {
+      render(
+        <ImageLightbox
+          images={images}
+          open
+          index={2}
+          onOpenChange={onOpenChange}
+          onIndexChange={onIndexChange}
+        />
+      );
+    });
+
+    it("wraps to the first index when advancing past the end", async () => {
+      await actions.clickNext();
+      expect(onIndexChange).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("given it is open at the first index", () => {
+    beforeEach(() => {
+      render(
+        <ImageLightbox
+          images={images}
+          open
+          index={0}
+          onOpenChange={onOpenChange}
+          onIndexChange={onIndexChange}
+        />
+      );
+    });
+
+    it("wraps to the last index when going before the start", async () => {
+      await actions.clickPrev();
+      expect(onIndexChange).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("given it is closed", () => {
+    beforeEach(() => {
+      render(
+        <ImageLightbox
+          images={images}
+          open={false}
+          index={1}
+          onOpenChange={onOpenChange}
+          onIndexChange={onIndexChange}
+        />
+      );
+    });
+
+    it("renders no image", () => {
+      expect(elements.queryCurrentImage()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.tsx
+++ b/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.tsx
@@ -1,0 +1,118 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+
+import type { ImageLightboxProps } from "./image-lightbox.type";
+
+export function ImageLightbox({
+  images,
+  open,
+  index,
+  onOpenChange,
+  onIndexChange,
+}: ImageLightboxProps) {
+  if (images.length === 0) return null;
+
+  const safeIndex = Math.min(Math.max(index, 0), images.length - 1);
+  const current = images[safeIndex];
+
+  const wrap = (next: number) => (next + images.length) % images.length;
+
+  const goNext = () => onIndexChange(wrap(safeIndex + 1));
+  const goPrev = () => onIndexChange(wrap(safeIndex - 1));
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      goNext();
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      goPrev();
+    }
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/85 backdrop-blur-sm" />
+        <DialogPrimitive.Content
+          onKeyDown={handleKeyDown}
+          className="gap-lg p-2xl fixed inset-0 z-50 flex flex-col items-center justify-center focus:outline-none"
+        >
+          <DialogPrimitive.Title className="sr-only">
+            {current.alt}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Screenshot {safeIndex + 1} of {images.length}
+          </DialogPrimitive.Description>
+
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="bg-foreground/15 text-background hover:bg-foreground/25 absolute top-4 right-4 flex h-10 w-10 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+          >
+            <X className="h-5 w-5" />
+          </DialogPrimitive.Close>
+
+          <div className="relative w-full max-w-3xl">
+            <img
+              src={current.src}
+              alt={current.alt}
+              className="aspect-video w-full rounded-lg object-cover"
+            />
+            <NavArrow side="left" onClick={goPrev} />
+            <NavArrow side="right" onClick={goNext} />
+          </div>
+
+          <div className="flex max-w-full gap-2 overflow-x-auto">
+            {images.map((image, i) => (
+              <button
+                key={image.src}
+                type="button"
+                aria-label={`View screenshot ${i + 1}`}
+                aria-current={i === safeIndex}
+                onClick={() => onIndexChange(i)}
+                className={cn(
+                  "h-12 w-20 shrink-0 overflow-hidden rounded-md transition-opacity",
+                  i === safeIndex
+                    ? "ring-2 ring-white"
+                    : "opacity-55 hover:opacity-100"
+                )}
+              >
+                <img
+                  src={image.src}
+                  alt=""
+                  aria-hidden="true"
+                  className="h-full w-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+function NavArrow({
+  side,
+  onClick,
+}: {
+  side: "left" | "right";
+  onClick: () => void;
+}) {
+  const Icon = side === "left" ? ChevronLeft : ChevronRight;
+  return (
+    <button
+      type="button"
+      aria-label={side === "left" ? "Previous screenshot" : "Next screenshot"}
+      onClick={onClick}
+      className={cn(
+        "bg-foreground/40 text-background hover:bg-foreground/60 absolute top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none",
+        side === "left" ? "left-3" : "right-3"
+      )}
+    >
+      <Icon className="h-6 w-6" />
+    </button>
+  );
+}

--- a/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.type.ts
+++ b/savepoint-tanstack/src/shared/ui/image-lightbox/image-lightbox.type.ts
@@ -1,0 +1,12 @@
+export type LightboxImage = {
+  src: string;
+  alt: string;
+};
+
+export type ImageLightboxProps = {
+  images: LightboxImage[];
+  open: boolean;
+  index: number;
+  onOpenChange: (open: boolean) => void;
+  onIndexChange: (index: number) => void;
+};

--- a/savepoint-tanstack/src/shared/ui/image-lightbox/index.ts
+++ b/savepoint-tanstack/src/shared/ui/image-lightbox/index.ts
@@ -1,0 +1,2 @@
+export { ImageLightbox } from "./image-lightbox";
+export type { ImageLightboxProps, LightboxImage } from "./image-lightbox.type";

--- a/savepoint-tanstack/src/shared/ui/index.ts
+++ b/savepoint-tanstack/src/shared/ui/index.ts
@@ -12,6 +12,8 @@ export {
 } from "./collapsible";
 export { EmptyState } from "./empty-state";
 export type { EmptyStateProps } from "./empty-state";
+export { ImageLightbox } from "./image-lightbox";
+export type { ImageLightboxProps, LightboxImage } from "./image-lightbox";
 export { SegmentedControl } from "./segmented-control";
 export type {
   SegmentedControlOption,

--- a/savepoint-tanstack/src/widgets/game-card/ui/game-card/game-card.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-card/ui/game-card/game-card.test.tsx
@@ -154,7 +154,11 @@ describe("GameCard", () => {
     beforeEach(() => {
       render(
         <GameCard
-          game={{ ...baseGame, releaseYear: 2017, platforms: ["PC", "Switch"] }}
+          game={{
+            ...baseGame,
+            releaseYear: 2017,
+            platforms: ["PlayStation 5", "Nintendo Switch"],
+          }}
           density="detailed"
           asLink={false}
         />
@@ -165,8 +169,30 @@ describe("GameCard", () => {
       expect(screen.getByText("2017")).toBeDefined();
     });
 
-    it("renders the first platform", () => {
-      expect(screen.getByText("PC")).toBeDefined();
+    it("renders platforms through PlatformBadges with abbreviated labels", () => {
+      // PlatformBadges abbreviates "PlayStation 5" → "PS5" and
+      // "Nintendo Switch" → "Switch"; the old full-name chips are gone.
+      expect(screen.getByText("PS5")).toBeDefined();
+      expect(screen.getByText("Switch")).toBeDefined();
+      expect(screen.queryByText("PlayStation 5")).toBeNull();
+    });
+
+    it("does not render the old grey full-name chip", () => {
+      // Family color + variant coverage lives in PlatformBadges' own test;
+      // here we only prove GameCard routes platforms through that component.
+      expect(screen.queryByText("PlayStation 5")).toBeNull();
+    });
+  });
+
+  describe("given density='minimal' with no platforms", () => {
+    beforeEach(() => {
+      render(<GameCard game={baseGame} density="minimal" asLink={false} />);
+    });
+
+    it("renders no platform row", () => {
+      // minimal density renders no meta block at all; the related-games and
+      // library cover cards pass no platforms — PlatformBadges must not render.
+      expect(screen.queryByText("PS5")).toBeNull();
     });
   });
 });

--- a/savepoint-tanstack/src/widgets/game-card/ui/game-card/game-card.tsx
+++ b/savepoint-tanstack/src/widgets/game-card/ui/game-card/game-card.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 
+import { PlatformBadges } from "@/entities/game";
 import { buildCoverImageUrl } from "@/shared/lib/igdb-image";
 import { cn } from "@/shared/lib/utils";
 
@@ -95,16 +96,7 @@ export function GameCard({
                 </span>
               ) : null}
               {platforms.length > 0 ? (
-                <div className="gap-xs flex flex-wrap">
-                  {platforms.map((platform) => (
-                    <span
-                      key={platform}
-                      className="bg-secondary text-secondary-foreground px-xs py-2xs rounded text-xs"
-                    >
-                      {platform}
-                    </span>
-                  ))}
-                </div>
+                <PlatformBadges platforms={platforms} />
               ) : null}
             </div>
           ) : null}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AboutPanel } from "./about-panel";
+
+const elements = {
+  querySummary: () => screen.queryByLabelText("Game summary"),
+  getSummary: () => screen.getByLabelText("Game summary"),
+  queryFactsLabel: () => screen.queryByText("// GAME.DETAIL"),
+  queryReleaseYearTerm: () => screen.queryByText("Release year"),
+  queryReleaseYearValue: () => screen.queryByText("2017"),
+  queryDeveloperTerm: () => screen.queryByText("Developer"),
+  queryDeveloperValue: () => screen.queryByText("Team Cherry"),
+  queryPublisherTerm: () => screen.queryByText("Publisher"),
+  queryPublisherValue: () => screen.queryByText("Skybound Games"),
+};
+
+describe("AboutPanel", () => {
+  describe("given all facts are present", () => {
+    beforeEach(() => {
+      render(
+        <AboutPanel
+          summary="A challenging metroidvania."
+          releaseYear="2017"
+          developer="Team Cherry"
+          publisher="Skybound Games"
+        />
+      );
+    });
+
+    it("renders the summary text", () => {
+      expect(elements.getSummary().textContent).toBe(
+        "A challenging metroidvania."
+      );
+    });
+
+    it("renders the GAME.DETAIL facts label", () => {
+      expect(elements.queryFactsLabel()).not.toBeNull();
+    });
+
+    it("renders the release year", () => {
+      expect(elements.queryReleaseYearTerm()).not.toBeNull();
+      expect(elements.queryReleaseYearValue()).not.toBeNull();
+    });
+
+    it("renders the developer", () => {
+      expect(elements.queryDeveloperTerm()).not.toBeNull();
+      expect(elements.queryDeveloperValue()).not.toBeNull();
+    });
+
+    it("renders the publisher", () => {
+      expect(elements.queryPublisherTerm()).not.toBeNull();
+      expect(elements.queryPublisherValue()).not.toBeNull();
+    });
+  });
+
+  describe("given no summary", () => {
+    beforeEach(() => {
+      render(
+        <AboutPanel
+          summary={null}
+          releaseYear="2017"
+          developer="Team Cherry"
+          publisher="Skybound Games"
+        />
+      );
+    });
+
+    it("does not render the summary paragraph", () => {
+      expect(elements.querySummary()).toBeNull();
+    });
+  });
+
+  describe("given developer is absent", () => {
+    beforeEach(() => {
+      render(
+        <AboutPanel
+          summary="Some copy."
+          releaseYear="2017"
+          developer={null}
+          publisher="Skybound Games"
+        />
+      );
+    });
+
+    it("omits the developer row", () => {
+      expect(elements.queryDeveloperTerm()).toBeNull();
+    });
+
+    it("still renders the publisher row", () => {
+      expect(elements.queryPublisherTerm()).not.toBeNull();
+    });
+  });
+
+  describe("given publisher is absent", () => {
+    beforeEach(() => {
+      render(
+        <AboutPanel
+          summary="Some copy."
+          releaseYear="2017"
+          developer="Team Cherry"
+          publisher={null}
+        />
+      );
+    });
+
+    it("omits the publisher row", () => {
+      expect(elements.queryPublisherTerm()).toBeNull();
+    });
+  });
+
+  describe("given release year is absent", () => {
+    beforeEach(() => {
+      render(
+        <AboutPanel
+          summary="Some copy."
+          releaseYear={null}
+          developer="Team Cherry"
+          publisher="Skybound Games"
+        />
+      );
+    });
+
+    it("omits the release year row", () => {
+      expect(elements.queryReleaseYearTerm()).toBeNull();
+    });
+  });
+
+  describe("given every field is absent (title-only catalog)", () => {
+    beforeEach(() => {
+      render(
+        <div data-testid="about-host">
+          <AboutPanel
+            summary={null}
+            releaseYear={null}
+            developer={null}
+            publisher={null}
+          />
+        </div>
+      );
+    });
+
+    it("renders nothing at all (no summary, no facts label, no placeholder)", () => {
+      expect(elements.querySummary()).toBeNull();
+      expect(elements.queryFactsLabel()).toBeNull();
+      expect(screen.getByTestId("about-host").textContent).toBe("");
+    });
+
+    it("does not emit an em-dash placeholder", () => {
+      expect(screen.queryByText("—")).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.tsx
@@ -1,0 +1,55 @@
+import type { AboutPanelProps } from "./about-panel.type";
+
+type Fact = { term: string; value: string };
+
+export function AboutPanel({
+  summary,
+  releaseYear,
+  developer,
+  publisher,
+}: AboutPanelProps) {
+  const facts: Fact[] = [
+    releaseYear ? { term: "Release year", value: releaseYear } : null,
+    developer ? { term: "Developer", value: developer } : null,
+    publisher ? { term: "Publisher", value: publisher } : null,
+  ].filter((f): f is Fact => f !== null);
+
+  if (!summary && facts.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {summary ? (
+        <p
+          aria-label="Game summary"
+          className="text-body text-foreground/85 max-w-[720px] leading-relaxed"
+        >
+          {summary}
+        </p>
+      ) : null}
+
+      {facts.length > 0 ? (
+        <div className="gap-lg grid grid-cols-1 md:grid-cols-[max-content_1fr] md:items-baseline">
+          <TerminalLabel>{`// GAME.DETAIL`}</TerminalLabel>
+          <dl className="text-sm">
+            {facts.map((fact) => (
+              <div key={fact.term} className="flex gap-2">
+                <dt className="text-muted-foreground w-24">{fact.term}</dt>
+                <dd className="text-foreground">{fact.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function TerminalLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-muted-foreground font-mono text-xs tracking-wider uppercase">
+      {children}
+    </span>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/about-panel.type.ts
@@ -1,0 +1,6 @@
+export type AboutPanelProps = {
+  summary: string | null;
+  releaseYear: string | null;
+  developer: string | null;
+  publisher: string | null;
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/about-panel/index.ts
@@ -1,0 +1,2 @@
+export { AboutPanel } from "./about-panel";
+export type { AboutPanelProps } from "./about-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AddToTrackInvite } from "./add-to-track-invite";
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({ invalidate: vi.fn() }),
+  Link: ({ to, children, ...rest }: any) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/features/add-game/api/add-game-to-library-fn", () => ({
+  addGameToLibraryFn: vi.fn(),
+}));
+
+const elements = {
+  getRegion: () => screen.getByTestId("add-to-track-invite"),
+  queryAddButton: () =>
+    screen.queryByRole("button", { name: /Add .* to library/ }),
+  querySignInLink: () => screen.queryByRole("link", { name: "Sign in" }),
+  queryInvitationCopy: () => screen.queryByText(/start tracking/i),
+};
+
+describe("AddToTrackInvite", () => {
+  describe("given a signed-in viewer (not in library)", () => {
+    beforeEach(() => {
+      render(
+        <AddToTrackInvite igdbId={1234} gameTitle="Hollow Knight" isSignedIn />
+      );
+    });
+
+    it("renders an invitation to start tracking", () => {
+      expect(elements.getRegion()).toBeDefined();
+      expect(elements.queryInvitationCopy()).not.toBeNull();
+    });
+
+    it("offers an Add to library action and no sign-in link", () => {
+      expect(elements.queryAddButton()).not.toBeNull();
+      expect(elements.querySignInLink()).toBeNull();
+    });
+  });
+
+  describe("given a logged-out viewer", () => {
+    beforeEach(() => {
+      render(
+        <AddToTrackInvite
+          igdbId={1234}
+          gameTitle="Hollow Knight"
+          isSignedIn={false}
+        />
+      );
+    });
+
+    it("renders an invitation to start tracking", () => {
+      expect(elements.getRegion()).toBeDefined();
+      expect(elements.queryInvitationCopy()).not.toBeNull();
+    });
+
+    it("offers a sign-in link and no add-to-library action", () => {
+      expect(elements.querySignInLink()).not.toBeNull();
+      expect(elements.queryAddButton()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.tsx
@@ -1,0 +1,45 @@
+import { Link } from "@tanstack/react-router";
+import { BookOpen } from "lucide-react";
+
+import { AddFromGameDetailButton } from "@/features/add-game";
+import { Button } from "@/shared/ui/button";
+
+import type { AddToTrackInviteProps } from "./add-to-track-invite.type";
+
+export function AddToTrackInvite({
+  igdbId,
+  gameTitle,
+  isSignedIn,
+}: AddToTrackInviteProps) {
+  return (
+    <section
+      data-testid="add-to-track-invite"
+      aria-labelledby="track-invite-heading"
+      className="gap-md p-xl flex flex-col items-start"
+    >
+      <span
+        className="bg-primary/10 flex size-10 items-center justify-center rounded-full"
+        aria-hidden="true"
+      >
+        <BookOpen className="text-primary h-5 w-5" />
+      </span>
+      <div className="gap-2xs flex flex-col">
+        <h2 id="track-invite-heading" className="text-h3">
+          Start tracking {gameTitle}
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          {isSignedIn
+            ? "Add this to your library to log sessions, rate it, and keep a journal."
+            : "Sign in and add this to your library to log sessions, rate it, and keep a journal."}
+        </p>
+      </div>
+      {isSignedIn ? (
+        <AddFromGameDetailButton igdbId={igdbId} gameTitle={gameTitle} />
+      ) : (
+        <Button asChild>
+          <Link to="/login">Sign in</Link>
+        </Button>
+      )}
+    </section>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/add-to-track-invite.type.ts
@@ -1,0 +1,6 @@
+export type AddToTrackInviteProps = {
+  igdbId: number;
+  gameTitle: string;
+  /** Whether a viewer is authenticated. Drives add-vs-sign-in affordance. */
+  isSignedIn: boolean;
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/add-to-track-invite/index.ts
@@ -1,0 +1,2 @@
+export { AddToTrackInvite } from "./add-to-track-invite";
+export type { AddToTrackInviteProps } from "./add-to-track-invite.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.test.tsx
@@ -101,6 +101,7 @@ const buildData = (
   journalTeaser: [],
   journalCount: 0,
   playtimeTotalMinutes: 0,
+  playtimeSessionCount: 0,
   recentSessionMinutes: [],
 });
 

--- a/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.test.tsx
@@ -97,9 +97,11 @@ const buildData = (
 ): GameDetailData => ({
   game: buildGame(gameOverrides),
   igdbDetails: buildIgdbDetails(igdbOverrides),
-  relatedGames: [],
   libraryEntry,
   journalTeaser: [],
+  journalCount: 0,
+  playtimeTotalMinutes: 0,
+  recentSessionMinutes: [],
 });
 
 const elements = {
@@ -107,17 +109,20 @@ const elements = {
     screen.getByRole("heading", { name: "Hollow Knight", level: 1 }),
   queryBreadcrumbLibrary: () => screen.queryByRole("link", { name: "Library" }),
   queryBreadcrumbGames: () => screen.queryByRole("link", { name: "Games" }),
-  queryStatusPill: (label: string) =>
-    screen.queryByRole("tab", { name: label }),
+  queryStatusPill: () =>
+    screen.queryByRole("button", { name: /^Change library status:/ }),
+  queryAddToLibrary: () =>
+    screen.queryByRole("button", { name: "Add to library" }),
   queryStatusSwitcher: () => screen.queryByTestId("library-status-switcher"),
-  queryRatingSlider: () => screen.queryByRole("slider"),
+  queryRatingSliders: () => screen.queryAllByRole("slider"),
   queryMoreMenuTrigger: () =>
     screen.queryByRole("button", { name: "More library actions" }),
-  getOverviewTab: () => screen.getByRole("tab", { name: "Overview" }),
-  queryJournalTab: () => screen.queryByRole("tab", { name: /^Journal/ }),
-  queryTimesToBeatTab: () =>
-    screen.queryByRole("tab", { name: "Times to beat" }),
-  queryRelatedTab: () => screen.queryByRole("tab", { name: "Related" }),
+  queryAllTablists: () => screen.queryAllByRole("tablist"),
+  queryAllTabpanels: () => screen.queryAllByRole("tabpanel"),
+  queryOverviewTab: () => screen.queryByRole("tab", { name: "Overview" }),
+  queryJournalHeading: () => screen.queryByRole("heading", { name: "Journal" }),
+  queryRelatedSlot: () => screen.queryByTestId("related-games-slot"),
+  queryTimesToBeatSlot: () => screen.queryByTestId("times-to-beat-slot"),
   querySummary: () => screen.queryByLabelText("Game summary"),
   queryGameDetailLabel: () => screen.queryByText("// GAME.DETAIL"),
   queryGenresLabel: () => screen.queryByText("// GENRES"),
@@ -125,7 +130,28 @@ const elements = {
   getSummaryText: () => screen.getByLabelText("Game summary"),
   queryGenresList: () => screen.queryByLabelText("Genres"),
   queryPlatformsList: () => screen.queryByLabelText("Platforms"),
+  queryCriticScoreRing: () => screen.queryByLabelText("Critic score"),
+  queryRoundedScore: (rounded: string) => screen.queryByText(rounded),
+  queryAboutCard: () => screen.queryByTestId("game-detail-about-card"),
+  queryThemesTagsCard: () =>
+    screen.queryByTestId("game-detail-themes-tags-card"),
+  queryLegacyCatalogCard: () =>
+    screen.queryByTestId("game-detail-catalog-card"),
+  queryEyebrow: () => screen.queryByLabelText("Release metadata"),
+  queryYourRecord: () => screen.queryByTestId("your-record-panel"),
+  queryThemesLabel: () => screen.queryByText("// THEMES"),
+  queryEmDash: () => screen.queryByText("—"),
+  queryScreenshotsRegion: () =>
+    screen.queryByLabelText("Screenshots of Hollow Knight"),
+  queryTrackInvite: () => screen.queryByTestId("add-to-track-invite"),
+  querySignInLink: () => screen.queryByRole("link", { name: "Sign in" }),
+  getBentoGrid: () => screen.getByTestId("game-detail-bento-grid"),
 };
+
+const PRECEDING = Node.DOCUMENT_POSITION_PRECEDING;
+
+const precedes = (first: Element, second: Element): boolean =>
+  Boolean(second.compareDocumentPosition(first) & PRECEDING);
 
 describe("GameDetail", () => {
   describe("given an anonymous viewer with no slots", () => {
@@ -133,46 +159,101 @@ describe("GameDetail", () => {
       render(<GameDetail data={buildData(null)} viewerUserId={null} />);
     });
 
-    it("renders the game title, breadcrumbs, Overview tab, and metadata labels", () => {
+    it("renders the game title, breadcrumbs, and the About facts label", () => {
       expect(elements.getTitle()).toBeDefined();
       expect(elements.queryBreadcrumbLibrary()).not.toBeNull();
       expect(elements.queryBreadcrumbGames()).not.toBeNull();
-      expect(elements.getOverviewTab()).toBeDefined();
       expect(elements.queryGameDetailLabel()).not.toBeNull();
-      expect(elements.queryGenresLabel()).not.toBeNull();
-      expect(elements.queryPlatformsLabel()).not.toBeNull();
     });
 
-    it("does not render the status switcher or Journal tab for anonymous viewers", () => {
+    it("renders the panels inline with no tablist, tab, or tabpanel roles", () => {
+      expect(elements.queryAllTablists()).toHaveLength(0);
+      expect(elements.queryOverviewTab()).toBeNull();
+      expect(elements.queryAllTabpanels()).toHaveLength(0);
+    });
+
+    it("omits the genres and platforms rows when those are absent", () => {
+      expect(elements.queryGenresLabel()).toBeNull();
+      expect(elements.queryPlatformsLabel()).toBeNull();
+    });
+
+    it("does not render the status switcher or Journal panel for anonymous viewers", () => {
       expect(elements.queryStatusSwitcher()).toBeNull();
-      expect(elements.queryJournalTab()).toBeNull();
+      expect(elements.queryJournalHeading()).toBeNull();
     });
   });
 
   describe("given a signed-in viewer with no library entry", () => {
     beforeEach(() => {
-      render(<GameDetail data={buildData(null)} viewerUserId="user-1" />);
+      render(
+        <GameDetail
+          data={buildData(null, {
+            summary: "A challenging metroidvania.",
+            genres: [{ id: 12, name: "Adventure" }],
+            platforms: [{ id: 6, name: "PC (Microsoft Windows)" }],
+          })}
+          viewerUserId="user-1"
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
     });
 
-    it("renders the status switcher with all 5 pills unchecked", () => {
+    it("renders an Add to library action and no status pill", () => {
       expect(elements.queryStatusSwitcher()).not.toBeNull();
-      for (const label of [
-        "Up Next",
-        "Playing",
-        "Shelf",
-        "Played",
-        "Wishlist",
-      ]) {
-        expect(elements.queryStatusPill(label)).toHaveAttribute(
-          "aria-selected",
-          "false"
-        );
-      }
+      expect(elements.queryAddToLibrary()).not.toBeNull();
+      expect(elements.queryStatusPill()).toBeNull();
     });
 
-    it("does not render the rating slider or overflow menu when there is no entry", () => {
-      expect(elements.queryRatingSlider()).toBeNull();
+    it("does not render the overflow menu when there is no entry", () => {
       expect(elements.queryMoreMenuTrigger()).toBeNull();
+    });
+
+    it("replaces the personal panels with a single start-tracking invitation", () => {
+      expect(elements.queryTrackInvite()).not.toBeNull();
+      expect(elements.queryYourRecord()).toBeNull();
+      expect(elements.queryJournalHeading()).toBeNull();
+      expect(elements.queryTimesToBeatSlot()).toBeNull();
+    });
+
+    it("renders About and Themes as two separate cards (no merged catalog card)", () => {
+      expect(elements.queryAboutCard()).not.toBeNull();
+      expect(elements.queryThemesTagsCard()).not.toBeNull();
+      expect(elements.queryLegacyCatalogCard()).toBeNull();
+    });
+  });
+
+  describe("given a logged-out viewer with catalog data and slots", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(null, {
+            summary: "A challenging metroidvania.",
+            genres: [{ id: 12, name: "Adventure" }],
+            platforms: [{ id: 6, name: "PC (Microsoft Windows)" }],
+          })}
+          viewerUserId={null}
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
+    });
+
+    it("renders no personal panels", () => {
+      expect(elements.queryYourRecord()).toBeNull();
+      expect(elements.queryJournalHeading()).toBeNull();
+      expect(elements.queryTimesToBeatSlot()).toBeNull();
+      expect(elements.queryStatusSwitcher()).toBeNull();
+    });
+
+    it("renders About and Themes as two separate cards (no merged catalog card)", () => {
+      expect(elements.queryAboutCard()).not.toBeNull();
+      expect(elements.queryThemesTagsCard()).not.toBeNull();
+      expect(elements.queryLegacyCatalogCard()).toBeNull();
+    });
+
+    it("offers a start-tracking invitation with a sign-in affordance", () => {
+      expect(elements.queryTrackInvite()).not.toBeNull();
+      expect(elements.querySignInLink()).not.toBeNull();
+      expect(elements.queryAddToLibrary()).toBeNull();
     });
   });
 
@@ -186,25 +267,40 @@ describe("GameDetail", () => {
       );
     });
 
-    it("marks only the Playing pill as active", () => {
-      expect(elements.queryStatusPill("Playing")).toHaveAttribute(
-        "aria-selected",
-        "true"
-      );
-      expect(elements.queryStatusPill("Shelf")).toHaveAttribute(
-        "aria-selected",
-        "false"
+    it("shows a status pill reflecting the current status", () => {
+      expect(elements.queryStatusPill()).toHaveAccessibleName(
+        "Change library status: Playing"
       );
     });
 
-    it("renders the rating slider, overflow menu, and Journal tab", () => {
-      expect(elements.queryRatingSlider()).not.toBeNull();
+    it("renders exactly one rating slider (single-sourced in Your Record), overflow menu, and Journal panel", () => {
+      expect(elements.queryRatingSliders()).toHaveLength(1);
       expect(elements.queryMoreMenuTrigger()).not.toBeNull();
-      expect(elements.queryJournalTab()).not.toBeNull();
+      expect(elements.queryJournalHeading()).not.toBeNull();
     });
   });
 
-  describe("given both phase-2 slots are passed", () => {
+  describe("given both phase-2 slots are passed (in-library viewer)", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(buildLibraryEntry())}
+          viewerUserId="user-1"
+          relatedGamesSlot={<div data-testid="related-games-slot" />}
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
+    });
+
+    it("renders both slots inline with no tablist or tabpanel roles", () => {
+      expect(elements.queryRelatedSlot()).not.toBeNull();
+      expect(elements.queryTimesToBeatSlot()).not.toBeNull();
+      expect(elements.queryAllTablists()).toHaveLength(0);
+      expect(elements.queryAllTabpanels()).toHaveLength(0);
+    });
+  });
+
+  describe("given a related slot but no 'you' layer (logged out)", () => {
     beforeEach(() => {
       render(
         <GameDetail
@@ -216,9 +312,85 @@ describe("GameDetail", () => {
       );
     });
 
-    it("renders the Related tab and the Times to beat tab", () => {
-      expect(elements.queryRelatedTab()).not.toBeNull();
-      expect(elements.queryTimesToBeatTab()).not.toBeNull();
+    it("renders the catalog related slot but suppresses the personal times-to-beat slot", () => {
+      expect(elements.queryRelatedSlot()).not.toBeNull();
+      expect(elements.queryTimesToBeatSlot()).toBeNull();
+    });
+  });
+
+  describe("given a signed-in viewer with an entry and both phase-2 slots", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(buildLibraryEntry(), {
+            summary: "A challenging metroidvania.",
+            genres: [{ id: 12, name: "Adventure" }],
+            platforms: [{ id: 6, name: "PC (Microsoft Windows)" }],
+          })}
+          viewerUserId="user-1"
+          relatedGamesSlot={<div data-testid="related-games-slot" />}
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
+    });
+
+    it("renders every panel simultaneously, inline, with no game-detail tabpanels", () => {
+      expect(elements.querySummary()).not.toBeNull();
+      expect(elements.queryGameDetailLabel()).not.toBeNull();
+      expect(elements.queryGenresLabel()).not.toBeNull();
+      expect(elements.queryPlatformsLabel()).not.toBeNull();
+      expect(elements.queryJournalHeading()).not.toBeNull();
+      expect(elements.queryRelatedSlot()).not.toBeNull();
+      expect(elements.queryTimesToBeatSlot()).not.toBeNull();
+      expect(elements.queryAllTabpanels()).toHaveLength(0);
+    });
+
+    it("renders About and Themes as two separate cards when catalog data is present", () => {
+      expect(elements.queryAboutCard()).not.toBeNull();
+      expect(elements.queryThemesTagsCard()).not.toBeNull();
+      expect(elements.queryLegacyCatalogCard()).toBeNull();
+    });
+  });
+
+  describe("given a fully-populated in-library viewer with screenshots and both slots", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(buildLibraryEntry(), {
+            summary: "A challenging metroidvania.",
+            genres: [{ id: 12, name: "Adventure" }],
+            platforms: [{ id: 6, name: "PC (Microsoft Windows)" }],
+            screenshots: [
+              { id: 1, image_id: "abc123" },
+              { id: 2, image_id: "def456" },
+            ],
+          })}
+          viewerUserId="user-1"
+          relatedGamesSlot={<div data-testid="related-games-slot" />}
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
+    });
+
+    it("renders the screenshots strip above the bento grid", () => {
+      expect(
+        precedes(elements.queryScreenshotsRegion()!, elements.getBentoGrid())
+      ).toBe(true);
+    });
+
+    it("orders the bento cells Record, Times, About, Themes, Journal, Related", () => {
+      const record = elements.queryYourRecord()!;
+      const times = elements.queryTimesToBeatSlot()!;
+      const about = elements.queryAboutCard()!;
+      const themes = elements.queryThemesTagsCard()!;
+      const journal = elements.queryJournalHeading()!;
+      const related = elements.queryRelatedSlot()!;
+
+      expect(precedes(record, times)).toBe(true);
+      expect(precedes(times, about)).toBe(true);
+      expect(precedes(about, themes)).toBe(true);
+      expect(precedes(themes, journal)).toBe(true);
+      expect(precedes(journal, related)).toBe(true);
     });
   });
 
@@ -344,7 +516,7 @@ describe("GameDetail", () => {
     });
   });
 
-  describe("given igdbDetails with an involved developer company", () => {
+  describe("given igdbDetails with both a developer and publisher company", () => {
     beforeEach(() => {
       render(
         <GameDetail
@@ -367,10 +539,42 @@ describe("GameDetail", () => {
       );
     });
 
-    it("shows the developer name uppercased in the eyebrow row, not the publisher", () => {
+    it("shows the publisher name uppercased in the eyebrow row, not the developer", () => {
       const eyebrow = screen.getByLabelText("Release metadata");
-      expect(eyebrow.textContent).toContain("TEAM CHERRY");
-      expect(eyebrow.textContent).not.toContain("SKYBOUND");
+      expect(eyebrow.textContent).toContain("SKYBOUND GAMES");
+      expect(eyebrow.textContent).not.toContain("TEAM CHERRY");
+    });
+  });
+
+  describe("given igdbDetails with an aggregated rating", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(null, { aggregated_rating: 91.4 })}
+          viewerUserId={null}
+        />
+      );
+    });
+
+    it("renders the critic score ring with the rounded score", () => {
+      const ring = elements.queryCriticScoreRing();
+      expect(ring).not.toBeNull();
+      expect(elements.queryRoundedScore("91")).not.toBeNull();
+    });
+  });
+
+  describe("given igdbDetails with no aggregated rating", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(null, { aggregated_rating: undefined })}
+          viewerUserId={null}
+        />
+      );
+    });
+
+    it("does not render the critic score ring", () => {
+      expect(elements.queryCriticScoreRing()).toBeNull();
     });
   });
 
@@ -384,9 +588,11 @@ describe("GameDetail", () => {
       );
     });
 
-    it("renders the em-dash placeholder for both genres and platforms", () => {
-      expect(elements.queryGenresList()?.textContent).toBe("—");
-      expect(elements.queryPlatformsList()?.textContent).toBe("—");
+    it("omits the genres and platforms rows entirely", () => {
+      expect(elements.queryGenresList()).toBeNull();
+      expect(elements.queryPlatformsList()).toBeNull();
+      expect(elements.queryGenresLabel()).toBeNull();
+      expect(elements.queryPlatformsLabel()).toBeNull();
     });
   });
 
@@ -427,6 +633,107 @@ describe("GameDetail", () => {
     });
   });
 
+  describe("given a title-only game that is in the viewer's library", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(
+            buildLibraryEntry(),
+            {
+              summary: undefined,
+              genres: [],
+              platforms: [],
+              themes: [],
+              screenshots: undefined,
+              involved_companies: [],
+              aggregated_rating: undefined,
+            },
+            { releaseDate: null }
+          )}
+          viewerUserId="user-1"
+          timesToBeatSlot={<div data-testid="times-to-beat-slot" />}
+        />
+      );
+    });
+
+    it("renders the hero title, status pill, and the Your Record panel", () => {
+      expect(elements.getTitle()).toBeDefined();
+      expect(elements.queryStatusPill()).not.toBeNull();
+      expect(elements.queryYourRecord()).not.toBeNull();
+    });
+
+    it("renders the personal slots (Your Pace / Times to beat and Journal)", () => {
+      expect(elements.queryTimesToBeatSlot()).not.toBeNull();
+      expect(elements.queryJournalHeading()).not.toBeNull();
+    });
+
+    it("omits every catalog surface (eyebrow, critic ring, About, Themes & Tags, Screenshots, Related)", () => {
+      expect(elements.queryEyebrow()).toBeNull();
+      expect(elements.queryCriticScoreRing()).toBeNull();
+      expect(elements.queryAboutCard()).toBeNull();
+      expect(elements.queryThemesTagsCard()).toBeNull();
+      expect(elements.queryGameDetailLabel()).toBeNull();
+      expect(elements.queryThemesLabel()).toBeNull();
+      expect(elements.queryScreenshotsRegion()).toBeNull();
+      expect(elements.queryRelatedSlot()).toBeNull();
+    });
+
+    it("never renders an em-dash placeholder", () => {
+      expect(elements.queryEmDash()).toBeNull();
+    });
+  });
+
+  describe("given a game with no catalog facts but rich personal data", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={{
+            ...buildData(
+              buildLibraryEntry(),
+              {
+                summary: undefined,
+                genres: [],
+                platforms: [],
+                themes: [],
+                involved_companies: [],
+              },
+              { releaseDate: null }
+            ),
+            playtimeTotalMinutes: 600,
+            journalCount: 4,
+          }}
+          viewerUserId="user-1"
+        />
+      );
+    });
+
+    it("collapses both catalog cards rather than rendering an empty box", () => {
+      expect(elements.queryAboutCard()).toBeNull();
+      expect(elements.queryThemesTagsCard()).toBeNull();
+      expect(elements.queryLegacyCatalogCard()).toBeNull();
+    });
+
+    it("does not emit an em-dash anywhere on the page", () => {
+      expect(elements.queryEmDash()).toBeNull();
+    });
+  });
+
+  describe("given a related-games slot that resolves to empty content", () => {
+    beforeEach(() => {
+      render(
+        <GameDetail
+          data={buildData(buildLibraryEntry())}
+          viewerUserId="user-1"
+          relatedGamesSlot={null}
+        />
+      );
+    });
+
+    it("does not render an empty Related card", () => {
+      expect(elements.queryRelatedSlot()).toBeNull();
+    });
+  });
+
   describe("given the user navigates between two games on the same route", () => {
     beforeEach(() => {
       const { rerender } = render(
@@ -448,11 +755,9 @@ describe("GameDetail", () => {
     });
 
     it("does not preserve the previous game's library status across navigation", () => {
-      expect(elements.queryStatusPill("Playing")).toHaveAttribute(
-        "aria-selected",
-        "false"
-      );
-      expect(elements.queryRatingSlider()).toBeNull();
+      expect(elements.queryStatusPill()).toBeNull();
+      expect(elements.queryAddToLibrary()).not.toBeNull();
+      expect(elements.queryRatingSliders()).toHaveLength(0);
     });
   });
 });

--- a/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.tsx
@@ -1,18 +1,22 @@
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
-import { GameCover, PlatformBadges } from "@/entities/game";
-import { JournalTeaser } from "@/entities/journal-entry";
+import { CriticScoreRing, GameCover } from "@/entities/game";
 import { ComposeJournalEntryDialog } from "@/features/compose-journal-entry";
 import {
   buildCoverImageUrl,
   buildScreenshotUrl,
 } from "@/shared/lib/igdb-image";
-import { cn } from "@/shared/lib/utils";
-import { Badge } from "@/shared/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import { Card } from "@/shared/ui/card";
 
+import { AboutPanel } from "../about-panel";
+import { AddToTrackInvite } from "../add-to-track-invite";
+import { JournalPanel } from "../journal-panel";
 import { LibraryStatusSwitcher } from "../library-status-switcher";
+import { RelatedPanel } from "../related-panel";
+import { ScreenshotsPanel } from "../screenshots-panel";
+import { ThemesTagsPanel } from "../themes-tags-panel";
+import { YourRecordPanel } from "../your-record-panel";
 import type { GameDetailProps } from "./game-detail.type";
 
 export function GameDetail({
@@ -21,7 +25,14 @@ export function GameDetail({
   relatedGamesSlot,
   timesToBeatSlot,
 }: GameDetailProps) {
-  const { game, igdbDetails, libraryEntry, journalTeaser } = data;
+  const {
+    game,
+    igdbDetails,
+    libraryEntry,
+    journalTeaser,
+    journalCount,
+    playtimeTotalMinutes,
+  } = data;
   const [composeOpen, setComposeOpen] = useState(false);
   const coverUrl = buildCoverImageUrl(game.coverImage, "t_cover_big_2x");
 
@@ -30,29 +41,43 @@ export function GameDetail({
     : null;
 
   const summary = igdbDetails.summary ?? null;
+  const themes = igdbDetails.themes?.map((t) => t.name) ?? [];
   const genres = igdbDetails.genres?.map((g) => g.name) ?? [];
   const platforms = igdbDetails.platforms?.map((p) => p.name) ?? [];
   const developer =
     igdbDetails.involved_companies?.find((c) => c.developer)?.company.name ??
     null;
+  const publisher =
+    igdbDetails.involved_companies?.find((c) => c.publisher)?.company.name ??
+    null;
   const screenshotBgUrl = buildScreenshotUrl(
     igdbDetails.screenshots?.[0]?.image_id
   );
 
-  const eyebrowParts: string[] = [
-    releaseYear,
-    developer,
-    genres.length > 0 ? genres.slice(0, 2).join(", ") : null,
-  ]
+  const criticScore = igdbDetails.aggregated_rating ?? null;
+
+  const eyebrowParts: string[] = [releaseYear, publisher, genres[0] ?? null]
     .filter((p): p is string => Boolean(p))
     .map((p) => p.toUpperCase());
 
-  const journalCount = journalTeaser.length;
-  const showJournalTab = viewerUserId !== null;
-  const showRelatedTab =
+  const hasAboutData = Boolean(
+    summary || releaseYear || developer || publisher
+  );
+  const hasThemesTagsData =
+    themes.length > 0 || genres.length > 0 || platforms.length > 0;
+
+  const isInLibrary = libraryEntry !== null;
+  const showPersonalPanels = viewerUserId !== null && isInLibrary;
+  const showTrackInvite = !showPersonalPanels;
+
+  const showScreenshotsPanel = (igdbDetails.screenshots?.length ?? 0) > 0;
+  const showJournalPanel = showPersonalPanels;
+  const showRelatedPanel =
     relatedGamesSlot !== null && relatedGamesSlot !== undefined;
-  const showTimesToBeatTab =
-    timesToBeatSlot !== null && timesToBeatSlot !== undefined;
+  const showTimesToBeatPanel =
+    showPersonalPanels &&
+    timesToBeatSlot !== null &&
+    timesToBeatSlot !== undefined;
 
   return (
     <main className="relative flex flex-col">
@@ -121,28 +146,34 @@ export function GameDetail({
             <GameCover src={coverUrl} alt={`Cover for ${game.title}`} />
           </div>
           <div className="min-w-0 pb-1.5">
-            {eyebrowParts.length > 0 ? (
-              <p
-                aria-label="Release metadata"
-                className="text-caption text-muted-foreground mb-2.5 flex flex-wrap items-center gap-2 tracking-widest uppercase"
-              >
-                {eyebrowParts.map((part, i) => (
-                  <span key={i} className="flex items-center gap-2">
-                    {i > 0 ? (
-                      <span
-                        aria-hidden="true"
-                        className="bg-muted-foreground inline-block h-[3px] w-[3px] rounded-full"
-                      />
-                    ) : null}
-                    {part}
-                  </span>
-                ))}
-              </p>
-            ) : null}
+            <div className="flex items-start justify-between gap-6">
+              <div className="min-w-0 flex-1">
+                {eyebrowParts.length > 0 ? (
+                  <p
+                    aria-label="Release metadata"
+                    className="text-caption text-muted-foreground mb-2.5 flex flex-wrap items-center gap-2 tracking-widest uppercase"
+                  >
+                    {eyebrowParts.map((part, i) => (
+                      <span key={i} className="flex items-center gap-2">
+                        {i > 0 ? (
+                          <span
+                            aria-hidden="true"
+                            className="bg-muted-foreground inline-block h-[3px] w-[3px] rounded-full"
+                          />
+                        ) : null}
+                        {part}
+                      </span>
+                    ))}
+                  </p>
+                ) : null}
 
-            <h1 className="text-h1 mb-4 tracking-tight break-words">
-              {game.title}
-            </h1>
+                <h1 className="text-h1 mb-4 tracking-tight break-words">
+                  {game.title}
+                </h1>
+              </div>
+
+              <CriticScoreRing value={criticScore} />
+            </div>
 
             {viewerUserId !== null ? (
               <LibraryStatusSwitcher
@@ -155,72 +186,90 @@ export function GameDetail({
           </div>
         </section>
 
-        <Tabs defaultValue="overview" className="gap-lg mt-8 flex flex-col">
-          <TabsList
-            aria-label="Game detail sections"
-            className="gap-1 overflow-x-auto"
-          >
-            <TabsTrigger value="overview" className="px-3.5 pt-3 pb-3">
-              Overview
-            </TabsTrigger>
-            {showJournalTab ? (
-              <TabsTrigger value="journal" className="gap-1.5 px-3.5 pt-3 pb-3">
-                <span>Journal</span>
-                <span
-                  className={cn(
-                    "text-caption rounded-full px-1.5 py-0.5 leading-none",
-                    "bg-muted text-muted-foreground"
-                  )}
-                >
-                  {journalCount}
-                </span>
-              </TabsTrigger>
-            ) : null}
-            {showRelatedTab ? (
-              <TabsTrigger value="related" className="px-3.5 pt-3 pb-3">
-                Related
-              </TabsTrigger>
-            ) : null}
-            {showTimesToBeatTab ? (
-              <TabsTrigger value="times-to-beat" className="px-3.5 pt-3 pb-3">
-                Times to beat
-              </TabsTrigger>
-            ) : null}
-          </TabsList>
-
-          <TabsContent value="overview" className="gap-xl flex flex-col">
-            <OverviewBody
-              summary={summary}
-              releaseYear={releaseYear}
-              genres={genres}
-              platforms={platforms}
+        {showScreenshotsPanel ? (
+          <Card variant="flat" className="gap-md p-xl mt-8 flex flex-col">
+            <ScreenshotsPanel
+              screenshots={igdbDetails.screenshots}
+              gameTitle={game.title}
             />
-          </TabsContent>
+          </Card>
+        ) : null}
 
-          {showJournalTab ? (
-            <TabsContent value="journal" className="gap-md flex flex-col">
-              <h2 id="journal-teaser-heading" className="text-h3">
-                Journal
-              </h2>
-              <JournalTeaser
+        <div
+          data-testid="game-detail-bento-grid"
+          className="gap-lg mt-8 grid grid-cols-1 md:grid-cols-[1.35fr_1fr] md:items-start"
+        >
+          {showPersonalPanels ? (
+            <Card variant="flat" className="gap-md p-xl flex flex-col">
+              <YourRecordPanel
+                itemId={libraryEntry?.id ?? null}
+                rating={libraryEntry?.rating ?? null}
+                playtimeTotalMinutes={playtimeTotalMinutes}
+                journalCount={journalCount}
+                gameTitle={game.title}
+                onLogSession={() => setComposeOpen(true)}
+              />
+            </Card>
+          ) : null}
+
+          {showTrackInvite ? (
+            <Card variant="flat" className="flex flex-col">
+              <AddToTrackInvite
+                igdbId={game.igdbId}
+                gameTitle={game.title}
+                isSignedIn={viewerUserId !== null}
+              />
+            </Card>
+          ) : null}
+
+          {showTimesToBeatPanel ? (
+            <Card variant="flat" className="gap-md p-xl flex flex-col">
+              {timesToBeatSlot}
+            </Card>
+          ) : null}
+
+          {hasAboutData ? (
+            <Card
+              variant="flat"
+              data-testid="game-detail-about-card"
+              className="gap-lg p-xl flex flex-col"
+            >
+              <AboutPanel
+                summary={summary}
+                releaseYear={releaseYear}
+                developer={developer}
+                publisher={publisher}
+              />
+            </Card>
+          ) : null}
+
+          {hasThemesTagsData ? (
+            <Card
+              variant="flat"
+              data-testid="game-detail-themes-tags-card"
+              className="gap-lg p-xl flex flex-col"
+            >
+              <ThemesTagsPanel
+                themes={themes}
+                genres={genres}
+                platforms={platforms}
+              />
+            </Card>
+          ) : null}
+
+          {showJournalPanel ? (
+            <Card variant="flat" className="gap-md p-xl flex flex-col">
+              <JournalPanel
                 entries={journalTeaser}
                 onAddEntryClick={() => setComposeOpen(true)}
               />
-            </TabsContent>
+            </Card>
           ) : null}
 
-          {showRelatedTab ? (
-            <TabsContent value="related" className="gap-md flex flex-col">
-              {relatedGamesSlot}
-            </TabsContent>
+          {showRelatedPanel ? (
+            <RelatedPanel>{relatedGamesSlot}</RelatedPanel>
           ) : null}
-
-          {showTimesToBeatTab ? (
-            <TabsContent value="times-to-beat" className="gap-md flex flex-col">
-              {timesToBeatSlot}
-            </TabsContent>
-          ) : null}
-        </Tabs>
+        </div>
 
         {viewerUserId ? (
           <ComposeJournalEntryDialog
@@ -231,74 +280,5 @@ export function GameDetail({
         ) : null}
       </div>
     </main>
-  );
-}
-
-function OverviewBody({
-  summary,
-  releaseYear,
-  genres,
-  platforms,
-}: {
-  summary: string | null;
-  releaseYear: string | null;
-  genres: string[];
-  platforms: string[];
-}) {
-  return (
-    <>
-      {summary ? (
-        <p
-          aria-label="Game summary"
-          className="text-body text-foreground/85 max-w-[720px] leading-relaxed"
-        >
-          {summary}
-        </p>
-      ) : null}
-
-      <div className="gap-lg grid grid-cols-1 md:grid-cols-[max-content_1fr] md:items-baseline">
-        <TerminalLabel>{`// GAME.DETAIL`}</TerminalLabel>
-        <dl className="text-sm">
-          <div className="flex gap-2">
-            <dt className="text-muted-foreground w-24">Release year</dt>
-            <dd className="text-foreground">{releaseYear ?? "—"}</dd>
-          </div>
-        </dl>
-
-        <TerminalLabel>{`// GENRES`}</TerminalLabel>
-        {genres.length > 0 ? (
-          <ul aria-label="Genres" className="flex flex-wrap gap-1.5 text-sm">
-            {genres.map((g) => (
-              <li key={g}>
-                <Badge variant="secondary">{g}</Badge>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p aria-label="Genres" className="text-muted-foreground text-sm">
-            —
-          </p>
-        )}
-
-        <TerminalLabel>{`// PLATFORMS`}</TerminalLabel>
-        {platforms.length > 0 ? (
-          <div aria-label="Platforms">
-            <PlatformBadges platforms={platforms} />
-          </div>
-        ) : (
-          <p aria-label="Platforms" className="text-muted-foreground text-sm">
-            —
-          </p>
-        )}
-      </div>
-    </>
-  );
-}
-
-function TerminalLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="text-muted-foreground font-mono text-xs tracking-wider uppercase">
-      {children}
-    </span>
   );
 }

--- a/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.type.ts
@@ -23,6 +23,8 @@ export type GameDetailData = {
   journalCount: number;
   /** SUM of the viewer's logged playedMinutes for this game; 0 when none. */
   playtimeTotalMinutes: number;
+  /** Count of journal entries carrying non-null playedMinutes — the true denominator for average session length. */
+  playtimeSessionCount: number;
   /** Recent non-null playedMinutes, oldest→newest, bounded for a rhythm chart. */
   recentSessionMinutes: number[];
 };

--- a/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/game-detail/game-detail.type.ts
@@ -17,9 +17,14 @@ export type GameDetailData = {
    * persisted. The widget reads display data from here.
    */
   igdbDetails: GameDetailsResponseItem;
-  relatedGames: Game[];
   libraryEntry: LibraryItem | null;
   journalTeaser: JournalEntry[];
+  /** True count of the viewer's journal entries — NOT capped at the teaser limit. */
+  journalCount: number;
+  /** SUM of the viewer's logged playedMinutes for this game; 0 when none. */
+  playtimeTotalMinutes: number;
+  /** Recent non-null playedMinutes, oldest→newest, bounded for a rhythm chart. */
+  recentSessionMinutes: number[];
 };
 
 export type GameDetailProps = {

--- a/savepoint-tanstack/src/widgets/game-detail/ui/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/index.ts
@@ -1,4 +1,18 @@
+export { AboutPanel } from "./about-panel";
+export type { AboutPanelProps } from "./about-panel";
+export { AddToTrackInvite } from "./add-to-track-invite";
+export type { AddToTrackInviteProps } from "./add-to-track-invite";
 export { GameDetail } from "./game-detail";
 export type { GameDetailData, GameDetailProps } from "./game-detail";
+export { JournalPanel } from "./journal-panel";
+export type { JournalPanelProps } from "./journal-panel";
 export { LibraryStatusSwitcher } from "./library-status-switcher";
 export type { LibraryStatusSwitcherProps } from "./library-status-switcher";
+export { RelatedPanel } from "./related-panel";
+export type { RelatedPanelProps } from "./related-panel";
+export { ScreenshotsPanel } from "./screenshots-panel";
+export type { ScreenshotsPanelProps } from "./screenshots-panel";
+export { ThemesTagsPanel } from "./themes-tags-panel";
+export type { ThemesTagsPanelProps } from "./themes-tags-panel";
+export { YourRecordPanel } from "./your-record-panel";
+export type { YourRecordPanelProps } from "./your-record-panel";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/index.ts
@@ -1,0 +1,2 @@
+export { JournalPanel } from "./journal-panel";
+export type { JournalPanelProps } from "./journal-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { JournalEntry } from "../../../../../shared/lib/prisma/client.ts";
+import { JournalPanel } from "./journal-panel";
+
+function makeEntry(): JournalEntry {
+  return {
+    id: "entry-1",
+    userId: "user-1",
+    gameId: "game-1",
+    libraryItemId: null,
+    kind: "QUICK",
+    title: "Session note",
+    content: "Played for an hour.",
+    playedMinutes: null,
+    playSession: null,
+    mood: null,
+    tags: [],
+    visibility: "PRIVATE",
+    createdAt: new Date("2024-01-15T12:00:00Z"),
+    updatedAt: new Date("2024-01-15T12:00:00Z"),
+    publishedAt: null,
+  };
+}
+
+const onAddEntryClick = vi.fn();
+
+const elements = {
+  queryHeading: () => screen.queryByRole("heading", { name: "Journal" }),
+  queryEntryContent: () => screen.queryByText("Played for an hour."),
+  queryEmpty: () => screen.queryByText("No journal entries yet."),
+  getAddButton: () => screen.getByRole("button", { name: "Add entry" }),
+};
+
+describe("JournalPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given existing journal entries", () => {
+    beforeEach(() => {
+      render(
+        <JournalPanel
+          entries={[makeEntry()]}
+          onAddEntryClick={onAddEntryClick}
+        />
+      );
+    });
+
+    it("renders the Journal heading", () => {
+      expect(elements.queryHeading()).not.toBeNull();
+    });
+
+    it("renders the entry teaser content", () => {
+      expect(elements.queryEntryContent()).not.toBeNull();
+    });
+
+    it("invokes onAddEntryClick when the add affordance is clicked", async () => {
+      await userEvent.click(elements.getAddButton());
+      expect(onAddEntryClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given no journal entries", () => {
+    beforeEach(() => {
+      render(<JournalPanel entries={[]} onAddEntryClick={onAddEntryClick} />);
+    });
+
+    it("renders the empty-state invitation", () => {
+      expect(elements.queryEmpty()).not.toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.tsx
@@ -1,0 +1,14 @@
+import { JournalTeaser } from "@/entities/journal-entry";
+
+import type { JournalPanelProps } from "./journal-panel.type";
+
+export function JournalPanel({ entries, onAddEntryClick }: JournalPanelProps) {
+  return (
+    <>
+      <h2 id="journal-teaser-heading" className="text-h3">
+        Journal
+      </h2>
+      <JournalTeaser entries={entries} onAddEntryClick={onAddEntryClick} />
+    </>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/journal-panel/journal-panel.type.ts
@@ -1,0 +1,6 @@
+import type { JournalEntry } from "../../../../../shared/lib/prisma/client.ts";
+
+export type JournalPanelProps = {
+  entries: JournalEntry[];
+  onAddEntryClick: () => void;
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.test.tsx
@@ -70,10 +70,10 @@ const buildEntry = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
 });
 
 const elements = {
-  getPill: () =>
-    screen.getByRole("button", { name: /^Change library status:/ }),
-  queryPill: () =>
-    screen.queryByRole("button", { name: /^Change library status:/ }),
+  getPill: (label: string) =>
+    screen.getByRole("button", { name: `Change library status: ${label}` }),
+  queryPill: (label: string) =>
+    screen.queryByRole("button", { name: `Change library status: ${label}` }),
   getAddToLibrary: () => screen.getByRole("button", { name: "Add to library" }),
   queryAddToLibrary: () =>
     screen.queryByRole("button", { name: "Add to library" }),
@@ -87,7 +87,7 @@ const elements = {
 };
 
 const actions = {
-  openMenu: async () => userEvent.click(elements.getPill()),
+  openMenu: async (label: string) => userEvent.click(elements.getPill(label)),
   selectStatus: async (label: string) =>
     userEvent.click(elements.getStatusOption(label)),
 };
@@ -118,9 +118,7 @@ describe("LibraryStatusSwitcher", () => {
     });
 
     it("shows a pill labelled with the current status", () => {
-      expect(elements.getPill()).toHaveAccessibleName(
-        "Change library status: Playing"
-      );
+      expect(elements.getPill("Playing")).toBeDefined();
     });
 
     it("does not render a rating control (rating lives in Your Record)", () => {
@@ -137,7 +135,7 @@ describe("LibraryStatusSwitcher", () => {
 
     describe("when the pill is clicked open", () => {
       beforeEach(async () => {
-        await actions.openMenu();
+        await actions.openMenu("Playing");
       });
 
       it("opens a menu listing all 5 statuses", () => {
@@ -187,9 +185,7 @@ describe("LibraryStatusSwitcher", () => {
 
         it("reflects the new status on the pill", async () => {
           await waitFor(() => {
-            expect(elements.getPill()).toHaveAccessibleName(
-              "Change library status: Shelf"
-            );
+            expect(elements.getPill("Shelf")).toBeDefined();
           });
         });
       });
@@ -224,13 +220,11 @@ describe("LibraryStatusSwitcher", () => {
           entry={buildEntry({ status: "UP_NEXT", hasBeenPlayed: true })}
         />
       );
-      await actions.openMenu();
+      await actions.openMenu("Replay");
     });
 
     it("labels Up Next as Replay on the pill and in the menu", () => {
-      expect(elements.queryPill()).toHaveAccessibleName(
-        "Change library status: Replay"
-      );
+      expect(elements.queryPill("Replay")).not.toBeNull();
       expect(
         screen.getByRole("menuitemradio", { name: "Replay" })
       ).toBeDefined();
@@ -254,7 +248,7 @@ describe("LibraryStatusSwitcher", () => {
 
     it("renders an Add to library action instead of a status pill", () => {
       expect(elements.queryAddToLibrary()).not.toBeNull();
-      expect(elements.queryPill()).toBeNull();
+      expect(elements.queryPill("Up Next")).toBeNull();
     });
 
     it("does not render a rating control", () => {
@@ -287,7 +281,7 @@ describe("LibraryStatusSwitcher", () => {
           entry={buildEntry()}
         />
       );
-      await actions.openMenu();
+      await actions.openMenu("Playing");
     });
 
     it("opens the status menu inside a bottom sheet", () => {

--- a/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { addGameToLibraryFn } from "@/features/add-game/api/add-game-to-library-fn";
 import { deleteLibraryItemFn } from "@/features/manage-library-entry/api/delete-library-item-fn";
@@ -35,6 +35,23 @@ vi.mock("@/features/manage-library-entry/api/search-platforms-fn", () => ({
   searchPlatformsFn: vi.fn(() => Promise.resolve([])),
 }));
 
+const DESKTOP_QUERY = "(min-width: 768px)";
+
+const setViewport = (variant: "desktop" | "mobile") => {
+  const isDesktop = variant === "desktop";
+  const matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === DESKTOP_QUERY ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  vi.stubGlobal("matchMedia", matchMedia);
+};
+
 const buildEntry = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
   id: 42,
   status: "PLAYING",
@@ -53,66 +70,41 @@ const buildEntry = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
 });
 
 const elements = {
-  getPill: (label: string) => screen.getByRole("tab", { name: label }),
+  getPill: () =>
+    screen.getByRole("button", { name: /^Change library status:/ }),
+  queryPill: () =>
+    screen.queryByRole("button", { name: /^Change library status:/ }),
+  getAddToLibrary: () => screen.getByRole("button", { name: "Add to library" }),
+  queryAddToLibrary: () =>
+    screen.queryByRole("button", { name: "Add to library" }),
+  getMenu: () => screen.getByRole("menu", { name: "Set status" }),
+  queryMenu: () => screen.queryByRole("menu", { name: "Set status" }),
+  getStatusOption: (label: string) =>
+    screen.getByRole("menuitemradio", { name: label }),
+  queryRating: () => screen.queryByRole("slider"),
   getMoreTrigger: () =>
     screen.getByRole("button", { name: "More library actions" }),
 };
 
 const actions = {
-  clickPill: async (label: string) => userEvent.click(elements.getPill(label)),
+  openMenu: async () => userEvent.click(elements.getPill()),
+  selectStatus: async (label: string) =>
+    userEvent.click(elements.getStatusOption(label)),
 };
 
 describe("LibraryStatusSwitcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setViewport("desktop");
   });
 
-  describe("given no library entry yet", () => {
-    beforeEach(() => {
-      vi.mocked(addGameToLibraryFn).mockResolvedValue(
-        buildEntry({ status: "UP_NEXT" })
-      );
-      render(
-        <LibraryStatusSwitcher
-          igdbId={1234}
-          gameTitle="Hollow Knight"
-          entry={null}
-        />
-      );
-    });
-
-    it("renders all 5 pills with no active selection", () => {
-      for (const label of [
-        "Up Next",
-        "Playing",
-        "Shelf",
-        "Played",
-        "Wishlist",
-      ]) {
-        expect(elements.getPill(label)).toHaveAttribute(
-          "aria-selected",
-          "false"
-        );
-      }
-    });
-
-    describe("when the user clicks the Up Next pill", () => {
-      beforeEach(async () => {
-        await actions.clickPill("Up Next");
-      });
-
-      it("calls addGameToLibraryFn with the chosen status", async () => {
-        await waitFor(() => {
-          expect(vi.mocked(addGameToLibraryFn)).toHaveBeenCalledWith({
-            data: { igdbId: 1234, status: "UP_NEXT" },
-          });
-        });
-      });
-    });
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  describe("given an existing entry with status PLAYING", () => {
+  describe("given an existing entry with status PLAYING (desktop)", () => {
     beforeEach(() => {
+      setViewport("desktop");
       vi.mocked(updateLibraryItemFn).mockResolvedValue(
         buildEntry({ status: "SHELF" })
       );
@@ -125,43 +117,85 @@ describe("LibraryStatusSwitcher", () => {
       );
     });
 
-    it("marks the Playing pill as active", () => {
-      expect(elements.getPill("Playing")).toHaveAttribute(
-        "aria-selected",
-        "true"
+    it("shows a pill labelled with the current status", () => {
+      expect(elements.getPill()).toHaveAccessibleName(
+        "Change library status: Playing"
       );
     });
 
-    it("renders the rating slider", () => {
-      expect(screen.getByRole("slider")).toBeDefined();
+    it("does not render a rating control (rating lives in Your Record)", () => {
+      expect(elements.queryRating()).toBeNull();
     });
 
-    it("renders the overflow menu trigger", () => {
+    it("keeps the overflow / remove affordance available", () => {
       expect(elements.getMoreTrigger()).toBeDefined();
     });
 
-    describe("when the user clicks the Shelf pill", () => {
+    it("does not show the status menu until the pill is clicked", () => {
+      expect(elements.queryMenu()).toBeNull();
+    });
+
+    describe("when the pill is clicked open", () => {
       beforeEach(async () => {
-        await actions.clickPill("Shelf");
+        await actions.openMenu();
       });
 
-      it("calls updateLibraryItemFn with the chosen status", async () => {
-        await waitFor(() => {
-          expect(vi.mocked(updateLibraryItemFn)).toHaveBeenCalledWith({
-            data: { itemId: 42, status: "SHELF" },
+      it("opens a menu listing all 5 statuses", () => {
+        const menu = elements.getMenu();
+        for (const label of [
+          "Wishlist",
+          "Shelf",
+          "Up Next",
+          "Playing",
+          "Played",
+        ]) {
+          expect(
+            within(menu).getByRole("menuitemradio", { name: label })
+          ).toBeDefined();
+        }
+      });
+
+      it("checks the current status option", () => {
+        expect(elements.getStatusOption("Playing")).toHaveAttribute(
+          "aria-checked",
+          "true"
+        );
+        expect(elements.getStatusOption("Shelf")).toHaveAttribute(
+          "aria-checked",
+          "false"
+        );
+      });
+
+      describe("and a different status is selected", () => {
+        beforeEach(async () => {
+          await actions.selectStatus("Shelf");
+        });
+
+        it("calls updateLibraryItemFn with the chosen status", async () => {
+          await waitFor(() => {
+            expect(vi.mocked(updateLibraryItemFn)).toHaveBeenCalledWith({
+              data: { itemId: 42, status: "SHELF" },
+            });
+          });
+        });
+
+        it("closes the menu", async () => {
+          await waitFor(() => {
+            expect(elements.queryMenu()).toBeNull();
+          });
+        });
+
+        it("reflects the new status on the pill", async () => {
+          await waitFor(() => {
+            expect(elements.getPill()).toHaveAccessibleName(
+              "Change library status: Shelf"
+            );
           });
         });
       });
-
-      it("flips the active pill to Shelf optimistically", () => {
-        expect(elements.getPill("Shelf")).toHaveAttribute(
-          "aria-selected",
-          "true"
-        );
-      });
     });
 
-    describe("when deleteLibraryItemFn is invoked via the overflow menu", () => {
+    describe("when removed via the overflow menu", () => {
       beforeEach(async () => {
         vi.mocked(deleteLibraryItemFn).mockResolvedValue(undefined as never);
         await userEvent.click(elements.getMoreTrigger());
@@ -177,6 +211,95 @@ describe("LibraryStatusSwitcher", () => {
           });
         });
       });
+    });
+  });
+
+  describe("given an existing UP_NEXT entry that has been played (desktop)", () => {
+    beforeEach(async () => {
+      setViewport("desktop");
+      render(
+        <LibraryStatusSwitcher
+          igdbId={1234}
+          gameTitle="Hollow Knight"
+          entry={buildEntry({ status: "UP_NEXT", hasBeenPlayed: true })}
+        />
+      );
+      await actions.openMenu();
+    });
+
+    it("labels Up Next as Replay on the pill and in the menu", () => {
+      expect(elements.queryPill()).toHaveAccessibleName(
+        "Change library status: Replay"
+      );
+      expect(
+        screen.getByRole("menuitemradio", { name: "Replay" })
+      ).toBeDefined();
+    });
+  });
+
+  describe("given no library entry yet (desktop)", () => {
+    beforeEach(() => {
+      setViewport("desktop");
+      vi.mocked(addGameToLibraryFn).mockResolvedValue(
+        buildEntry({ status: "UP_NEXT" })
+      );
+      render(
+        <LibraryStatusSwitcher
+          igdbId={1234}
+          gameTitle="Hollow Knight"
+          entry={null}
+        />
+      );
+    });
+
+    it("renders an Add to library action instead of a status pill", () => {
+      expect(elements.queryAddToLibrary()).not.toBeNull();
+      expect(elements.queryPill()).toBeNull();
+    });
+
+    it("does not render a rating control", () => {
+      expect(elements.queryRating()).toBeNull();
+    });
+
+    describe("when a status is chosen from the add menu", () => {
+      beforeEach(async () => {
+        await userEvent.click(elements.getAddToLibrary());
+        await actions.selectStatus("Up Next");
+      });
+
+      it("calls addGameToLibraryFn with the chosen status", async () => {
+        await waitFor(() => {
+          expect(vi.mocked(addGameToLibraryFn)).toHaveBeenCalledWith({
+            data: { igdbId: 1234, status: "UP_NEXT" },
+          });
+        });
+      });
+    });
+  });
+
+  describe("given an existing entry on mobile", () => {
+    beforeEach(async () => {
+      setViewport("mobile");
+      render(
+        <LibraryStatusSwitcher
+          igdbId={1234}
+          gameTitle="Hollow Knight"
+          entry={buildEntry()}
+        />
+      );
+      await actions.openMenu();
+    });
+
+    it("opens the status menu inside a bottom sheet", () => {
+      expect(elements.getMenu()).toBeDefined();
+      expect(screen.getByTestId("status-sheet")).toBeDefined();
+    });
+
+    it("checks the current status inside the sheet", () => {
+      expect(elements.getStatusOption("Playing")).toHaveAttribute(
+        "aria-checked",
+        "true"
+      );
     });
   });
 });

--- a/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/library-status-switcher.tsx
@@ -1,14 +1,19 @@
 import { useRouter } from "@tanstack/react-router";
-import { MoreHorizontal } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Check, ChevronDown, MoreHorizontal, Plus } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 
-import { STATUS_ENTRIES } from "@/entities/library-item/model";
+import {
+  getStatusEntry,
+  getUpNextLabel,
+  LIBRARY_STATUS_VALUES,
+} from "@/entities/library-item/model";
 import { addGameToLibraryFn } from "@/features/add-game/api/add-game-to-library-fn";
 import { LibraryModal } from "@/features/manage-library-entry";
 import { deleteLibraryItemFn } from "@/features/manage-library-entry/api/delete-library-item-fn";
 import { updateLibraryItemFn } from "@/features/manage-library-entry/api/update-library-item-fn";
 import { getErrorMessage } from "@/shared/lib/errors";
+import { cn } from "@/shared/lib/utils";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
@@ -16,14 +21,84 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
-import { RatingInput } from "@/shared/ui/rating-input";
-import { SegmentedControl } from "@/shared/ui/segmented-control";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
 
 import type {
   LibraryItem,
   LibraryItemStatus,
 } from "../../../../../shared/lib/prisma/client.ts";
 import type { LibraryStatusSwitcherProps } from "./library-status-switcher.type";
+import { useMediaQuery } from "./use-media-query";
+
+const DESKTOP_QUERY = "(min-width: 768px)";
+
+function labelForStatus(
+  status: LibraryItemStatus,
+  hasBeenPlayed: boolean
+): string {
+  if (status === "UP_NEXT") return getUpNextLabel(hasBeenPlayed);
+  return getStatusEntry(status).label;
+}
+
+type StatusMenuProps = {
+  currentStatus: LibraryItemStatus | null;
+  hasBeenPlayed: boolean;
+  pending: boolean;
+  onSelect: (status: LibraryItemStatus) => void;
+};
+
+function StatusMenu({
+  currentStatus,
+  hasBeenPlayed,
+  pending,
+  onSelect,
+}: StatusMenuProps) {
+  return (
+    <div role="menu" aria-label="Set status" className="gap-2xs flex flex-col">
+      {LIBRARY_STATUS_VALUES.map((value) => {
+        const entry = getStatusEntry(value);
+        const Icon = entry.icon;
+        const active = currentStatus === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="menuitemradio"
+            aria-checked={active}
+            disabled={pending}
+            onClick={() => onSelect(value)}
+            className={cn(
+              "gap-sm px-sm py-xs flex w-full items-center rounded-md text-left text-sm transition-colors",
+              "hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+              active && "font-semibold",
+              pending && "opacity-50"
+            )}
+          >
+            <span
+              className="flex size-7 shrink-0 items-center justify-center rounded-full"
+              style={{
+                backgroundColor: `color-mix(in oklch, var(--status-${entry.badgeVariant}) 16%, transparent)`,
+              }}
+            >
+              <Icon
+                className="h-4 w-4"
+                style={{ color: `var(--status-${entry.badgeVariant})` }}
+                aria-hidden="true"
+              />
+            </span>
+            <span className="flex-1">
+              {labelForStatus(value, hasBeenPlayed)}
+            </span>
+            {active ? (
+              <Check className="text-primary h-4 w-4" aria-hidden="true" />
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export function LibraryStatusSwitcher({
   igdbId,
@@ -31,27 +106,28 @@ export function LibraryStatusSwitcher({
   entry,
 }: LibraryStatusSwitcherProps) {
   const router = useRouter();
+  const isDesktop = useMediaQuery(DESKTOP_QUERY);
   const [optimisticEntry, setOptimisticEntry] = useState<LibraryItem | null>(
     entry
   );
   const [pending, setPending] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
 
   const currentStatus = optimisticEntry?.status ?? null;
-  const currentRating = optimisticEntry?.rating ?? null;
+  const hasBeenPlayed = optimisticEntry?.hasBeenPlayed ?? false;
   const itemId = optimisticEntry?.id ?? null;
 
-  const handleStatusClick = async (status: LibraryItemStatus) => {
+  const handleSelect = async (status: LibraryItemStatus) => {
+    setMenuOpen(false);
     if (pending) return;
     const previous = optimisticEntry;
     setPending(true);
     try {
       if (previous === null) {
-        const created = await addGameToLibraryFn({
-          data: { igdbId, status },
-        });
+        const created = await addGameToLibraryFn({ data: { igdbId, status } });
         setOptimisticEntry(created);
-        toast.success(`Added to library as ${labelFor(status)}`);
+        toast.success(`Added to library as ${labelForStatus(status, false)}`);
       } else {
         setOptimisticEntry({ ...previous, status });
         const updated = await updateLibraryItemFn({
@@ -60,26 +136,6 @@ export function LibraryStatusSwitcher({
         setOptimisticEntry(updated);
         toast.success("Library entry updated");
       }
-      await router.invalidate();
-    } catch (err: unknown) {
-      setOptimisticEntry(previous);
-      toast.error(getErrorMessage(err, "Something went wrong"));
-    } finally {
-      setPending(false);
-    }
-  };
-
-  const handleRatingChange = async (next: number | null) => {
-    if (itemId === null || pending) return;
-    const previous = optimisticEntry;
-    if (previous === null) return;
-    setOptimisticEntry({ ...previous, rating: next });
-    setPending(true);
-    try {
-      const updated = await updateLibraryItemFn({
-        data: { itemId, rating: next },
-      });
-      setOptimisticEntry(updated);
       await router.invalidate();
     } catch (err: unknown) {
       setOptimisticEntry(previous);
@@ -106,18 +162,73 @@ export function LibraryStatusSwitcher({
     }
   };
 
-  const segmentedOptions = useMemo(
-    () =>
-      STATUS_ENTRIES.map((entry) => {
-        const Icon = entry.icon;
-        return {
-          value: entry.value,
-          label: entry.label,
-          icon: <Icon className="h-3.5 w-3.5" />,
-          disabled: pending,
-        };
-      }),
-    [pending]
+  const renderTrigger = (onClick?: () => void) =>
+    currentStatus === null ? (
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        disabled={pending}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={onClick}
+      >
+        <Plus className="h-4 w-4" aria-hidden="true" />
+        Add to library
+      </Button>
+    ) : (
+      <button
+        type="button"
+        disabled={pending}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={onClick}
+        aria-label={`Change library status: ${labelForStatus(
+          currentStatus,
+          hasBeenPlayed
+        )}`}
+        className="gap-xs px-sm py-2xs inline-flex items-center rounded-md border text-sm font-semibold transition-colors"
+        style={{
+          borderColor: `color-mix(in oklch, var(--status-${
+            getStatusEntry(currentStatus).badgeVariant
+          }) 40%, var(--border))`,
+          backgroundColor: `color-mix(in oklch, var(--status-${
+            getStatusEntry(currentStatus).badgeVariant
+          }) 15%, transparent)`,
+        }}
+      >
+        {(() => {
+          const Icon = getStatusEntry(currentStatus).icon;
+          return (
+            <Icon
+              className="h-4 w-4"
+              style={{
+                color: `var(--status-${
+                  getStatusEntry(currentStatus).badgeVariant
+                })`,
+              }}
+              aria-hidden="true"
+            />
+          );
+        })()}
+        <span>{labelForStatus(currentStatus, hasBeenPlayed)}</span>
+        <ChevronDown
+          className={cn(
+            "text-muted-foreground ml-2xs h-4 w-4 transition-transform",
+            menuOpen && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </button>
+    );
+
+  const menu = (
+    <StatusMenu
+      currentStatus={currentStatus}
+      hasBeenPlayed={hasBeenPlayed}
+      pending={pending}
+      onSelect={handleSelect}
+    />
   );
 
   return (
@@ -125,23 +236,24 @@ export function LibraryStatusSwitcher({
       className="gap-sm flex flex-wrap items-center"
       data-testid="library-status-switcher"
     >
-      <SegmentedControl<LibraryItemStatus>
-        value={currentStatus ?? ""}
-        onValueChange={handleStatusClick}
-        options={segmentedOptions}
-        ariaLabel={`Library status for ${gameTitle}`}
-        scrollable
-      />
-
-      {itemId !== null ? (
-        <RatingInput
-          value={currentRating}
-          readOnly={false}
-          size="md"
-          onChange={handleRatingChange}
-          aria-label={`Rate ${gameTitle}`}
-        />
-      ) : null}
+      {isDesktop ? (
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>{renderTrigger()}</PopoverTrigger>
+          <PopoverContent align="start" className="w-64">
+            {menu}
+          </PopoverContent>
+        </Popover>
+      ) : (
+        <>
+          {renderTrigger(() => setMenuOpen(true))}
+          <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+            <SheetContent side="bottom" data-testid="status-sheet">
+              <SheetTitle>Set status</SheetTitle>
+              {menu}
+            </SheetContent>
+          </Sheet>
+        </>
+      )}
 
       {itemId !== null ? (
         <DropdownMenu>
@@ -191,8 +303,4 @@ export function LibraryStatusSwitcher({
       ) : null}
     </div>
   );
-}
-
-function labelFor(status: LibraryItemStatus): string {
-  return STATUS_ENTRIES.find((e) => e.value === status)?.label ?? status;
 }

--- a/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/use-media-query.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/library-status-switcher/use-media-query.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ * SSR-safe (false on the server / before mount). Local to the status switcher
+ * so it can pick the desktop popover vs. mobile sheet surface; mirrors the
+ * `command-palette` hook. Lift to `shared/lib/` if a third consumer appears.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/index.ts
@@ -1,0 +1,2 @@
+export { RelatedPanel } from "./related-panel";
+export type { RelatedPanelProps } from "./related-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { RelatedPanel } from "./related-panel";
+
+const elements = {
+  querySlot: () => screen.queryByTestId("related-games-slot"),
+};
+
+describe("RelatedPanel", () => {
+  describe("given a related-games slot", () => {
+    beforeEach(() => {
+      render(
+        <RelatedPanel>
+          <div data-testid="related-games-slot">Related games here</div>
+        </RelatedPanel>
+      );
+    });
+
+    it("renders the provided slot content", () => {
+      expect(elements.querySlot()).not.toBeNull();
+      expect(elements.querySlot()?.textContent).toBe("Related games here");
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.tsx
@@ -1,0 +1,5 @@
+import type { RelatedPanelProps } from "./related-panel.type";
+
+export function RelatedPanel({ children }: RelatedPanelProps) {
+  return <>{children}</>;
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/related-panel/related-panel.type.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export type RelatedPanelProps = {
+  /**
+   * Suspense-wrapped related-games slot supplied by the route. The widget
+   * stays prop-driven; the route owns the Suspense + Await + error boundary.
+   */
+  children: ReactNode;
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/index.ts
@@ -1,0 +1,5 @@
+export { ScreenshotsPanel } from "./screenshots-panel";
+export type {
+  Screenshot,
+  ScreenshotsPanelProps,
+} from "./screenshots-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ScreenshotsPanel } from "./screenshots-panel";
+
+const screenshots = [
+  { id: 1, image_id: "abc1" },
+  { id: 2, image_id: "abc2" },
+  { id: 3, image_id: "abc3" },
+];
+
+const elements = {
+  queryHeading: () => screen.queryByRole("heading", { name: "Screenshots" }),
+  getThumbnail: (n: number) =>
+    screen.getByRole("button", { name: `Open screenshot ${n}` }),
+  queryLightboxImage: (n: number) =>
+    screen.queryByRole("img", { name: `Screenshot ${n}` }),
+};
+
+const actions = {
+  openThumbnail: (n: number) => userEvent.click(elements.getThumbnail(n)),
+};
+
+describe("ScreenshotsPanel", () => {
+  describe("given screenshots exist", () => {
+    beforeEach(() => {
+      render(<ScreenshotsPanel screenshots={screenshots} gameTitle="FF7" />);
+    });
+
+    it("renders the Screenshots heading", () => {
+      expect(elements.queryHeading()).not.toBeNull();
+    });
+
+    it("renders a thumbnail for each screenshot", () => {
+      expect(elements.getThumbnail(1)).not.toBeNull();
+      expect(elements.getThumbnail(2)).not.toBeNull();
+      expect(elements.getThumbnail(3)).not.toBeNull();
+    });
+
+    it("does not show the lightbox before a thumbnail is clicked", () => {
+      expect(elements.queryLightboxImage(1)).toBeNull();
+    });
+
+    it("opens the lightbox at the clicked thumbnail's index", async () => {
+      await actions.openThumbnail(2);
+      expect(elements.queryLightboxImage(2)).not.toBeNull();
+    });
+  });
+
+  describe("given an empty screenshots array", () => {
+    beforeEach(() => {
+      render(<ScreenshotsPanel screenshots={[]} gameTitle="FF7" />);
+    });
+
+    it("renders nothing", () => {
+      expect(elements.queryHeading()).toBeNull();
+    });
+  });
+
+  describe("given screenshots are undefined", () => {
+    beforeEach(() => {
+      render(<ScreenshotsPanel screenshots={undefined} gameTitle="FF7" />);
+    });
+
+    it("renders nothing", () => {
+      expect(elements.queryHeading()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+import { buildScreenshotUrl } from "@/shared/lib/igdb-image";
+import { ImageLightbox } from "@/shared/ui/image-lightbox";
+
+import type { ScreenshotsPanelProps } from "./screenshots-panel.type";
+
+export function ScreenshotsPanel({
+  screenshots,
+  gameTitle,
+}: ScreenshotsPanelProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  if (!screenshots || screenshots.length === 0) return null;
+
+  const images = screenshots
+    .map((shot, i) => ({
+      thumb: buildScreenshotUrl(shot.image_id, "t_720p"),
+      full: buildScreenshotUrl(shot.image_id, "t_1080p"),
+      alt: `Screenshot ${i + 1}`,
+    }))
+    .filter(
+      (image): image is { thumb: string; full: string; alt: string } =>
+        image.thumb !== null && image.full !== null
+    );
+
+  if (images.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="screenshots-heading"
+      aria-label={`Screenshots of ${gameTitle}`}
+    >
+      <h2
+        id="screenshots-heading"
+        className="text-muted-foreground mb-md font-mono text-xs tracking-wider uppercase"
+      >
+        Screenshots
+      </h2>
+
+      <div className="gap-sm flex overflow-x-auto md:grid md:grid-cols-5 md:overflow-visible">
+        {images.map((image, i) => (
+          <button
+            key={image.full}
+            type="button"
+            aria-label={`Open screenshot ${i + 1}`}
+            onClick={() => setActiveIndex(i)}
+            className="ring-offset-background focus-visible:ring-ring w-48 shrink-0 overflow-hidden rounded-md leading-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none md:w-auto"
+          >
+            <img
+              src={image.thumb}
+              alt=""
+              aria-hidden="true"
+              className="aspect-video w-full object-cover transition-transform hover:scale-[1.03]"
+            />
+          </button>
+        ))}
+      </div>
+
+      <ImageLightbox
+        images={images.map((image) => ({ src: image.full, alt: image.alt }))}
+        open={activeIndex !== null}
+        index={activeIndex ?? 0}
+        onOpenChange={(open) => {
+          if (!open) setActiveIndex(null);
+        }}
+        onIndexChange={setActiveIndex}
+      />
+    </section>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.type.ts
@@ -1,0 +1,9 @@
+export type Screenshot = {
+  id: number;
+  image_id: string;
+};
+
+export type ScreenshotsPanelProps = {
+  screenshots: Screenshot[] | undefined;
+  gameTitle: string;
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/screenshots-panel/screenshots-panel.type.ts
@@ -1,7 +1,8 @@
-export type Screenshot = {
-  id: number;
-  image_id: string;
-};
+import type { GameDetailsResponseItem } from "@/shared/api/igdb";
+
+export type Screenshot = NonNullable<
+  GameDetailsResponseItem["screenshots"]
+>[number];
 
 export type ScreenshotsPanelProps = {
   screenshots: Screenshot[] | undefined;

--- a/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/index.ts
@@ -1,0 +1,2 @@
+export { ThemesTagsPanel } from "./themes-tags-panel";
+export type { ThemesTagsPanelProps } from "./themes-tags-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ThemesTagsPanel } from "./themes-tags-panel";
+
+const elements = {
+  queryThemesLabel: () => screen.queryByText("// THEMES"),
+  queryGenresLabel: () => screen.queryByText("// GENRES"),
+  queryPlatformsLabel: () => screen.queryByText("// PLATFORMS"),
+  queryThemesList: () => screen.queryByLabelText("Themes"),
+  queryGenresList: () => screen.queryByLabelText("Genres"),
+  queryPlatformsList: () => screen.queryByLabelText("Platforms"),
+};
+
+describe("ThemesTagsPanel", () => {
+  describe("given themes, genres, and platforms", () => {
+    beforeEach(() => {
+      render(
+        <ThemesTagsPanel
+          themes={["Action", "Fantasy"]}
+          genres={["Role-playing (RPG)", "Adventure"]}
+          platforms={["PC (Microsoft Windows)", "PlayStation 5"]}
+        />
+      );
+    });
+
+    it("renders each theme as a chip next to the THEMES label", () => {
+      expect(elements.queryThemesLabel()).not.toBeNull();
+      const list = elements.queryThemesList();
+      expect(list).not.toBeNull();
+      const items = within(list!).getAllByRole("listitem");
+      expect(items.map((i) => i.textContent)).toEqual(["Action", "Fantasy"]);
+    });
+
+    it("renders each genre as a chip next to the GENRES label", () => {
+      expect(elements.queryGenresLabel()).not.toBeNull();
+      const list = elements.queryGenresList();
+      expect(list).not.toBeNull();
+      const items = within(list!).getAllByRole("listitem");
+      expect(items.map((i) => i.textContent)).toEqual([
+        "Role-playing (RPG)",
+        "Adventure",
+      ]);
+    });
+
+    it("renders the platforms via PlatformBadges with their abbreviations", () => {
+      expect(elements.queryPlatformsLabel()).not.toBeNull();
+      const list = elements.queryPlatformsList();
+      expect(list).not.toBeNull();
+      expect(within(list!).getByText("PC")).toBeDefined();
+      expect(within(list!).getByText("PS5")).toBeDefined();
+    });
+  });
+
+  describe("given no themes", () => {
+    beforeEach(() => {
+      render(
+        <ThemesTagsPanel
+          themes={[]}
+          genres={["Adventure"]}
+          platforms={["PC (Microsoft Windows)"]}
+        />
+      );
+    });
+
+    it("omits the THEMES row", () => {
+      expect(elements.queryThemesLabel()).toBeNull();
+      expect(elements.queryThemesList()).toBeNull();
+    });
+
+    it("still renders genres and platforms", () => {
+      expect(elements.queryGenresLabel()).not.toBeNull();
+      expect(elements.queryPlatformsLabel()).not.toBeNull();
+    });
+  });
+
+  describe("given no genres", () => {
+    beforeEach(() => {
+      render(
+        <ThemesTagsPanel
+          themes={["Action"]}
+          genres={[]}
+          platforms={["PC (Microsoft Windows)"]}
+        />
+      );
+    });
+
+    it("omits the GENRES row", () => {
+      expect(elements.queryGenresLabel()).toBeNull();
+      expect(elements.queryGenresList()).toBeNull();
+    });
+  });
+
+  describe("given no platforms", () => {
+    beforeEach(() => {
+      render(
+        <ThemesTagsPanel
+          themes={["Action"]}
+          genres={["Adventure"]}
+          platforms={[]}
+        />
+      );
+    });
+
+    it("omits the PLATFORMS row", () => {
+      expect(elements.queryPlatformsLabel()).toBeNull();
+      expect(elements.queryPlatformsList()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.tsx
@@ -24,7 +24,9 @@ export function ThemesTagsPanel({
           <ul aria-label="Themes" className="flex flex-wrap gap-1.5 text-sm">
             {themes.map((theme) => (
               <li key={theme}>
-                <Badge variant="secondary" className="rounded-md">{theme}</Badge>
+                <Badge variant="secondary" className="rounded-md">
+                  {theme}
+                </Badge>
               </li>
             ))}
           </ul>
@@ -37,7 +39,9 @@ export function ThemesTagsPanel({
           <ul aria-label="Genres" className="flex flex-wrap gap-1.5 text-sm">
             {genres.map((genre) => (
               <li key={genre}>
-                <Badge variant="secondary" className="rounded-md">{genre}</Badge>
+                <Badge variant="secondary" className="rounded-md">
+                  {genre}
+                </Badge>
               </li>
             ))}
           </ul>

--- a/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.tsx
@@ -1,0 +1,65 @@
+import { PlatformBadges } from "@/entities/game";
+import { Badge } from "@/shared/ui/badge";
+
+import type { ThemesTagsPanelProps } from "./themes-tags-panel.type";
+
+export function ThemesTagsPanel({
+  themes,
+  genres,
+  platforms,
+}: ThemesTagsPanelProps) {
+  const hasThemes = themes.length > 0;
+  const hasGenres = genres.length > 0;
+  const hasPlatforms = platforms.length > 0;
+
+  if (!hasThemes && !hasGenres && !hasPlatforms) {
+    return null;
+  }
+
+  return (
+    <div className="gap-lg grid grid-cols-1 md:grid-cols-[max-content_1fr] md:items-baseline">
+      {hasThemes ? (
+        <>
+          <TerminalLabel>{`// THEMES`}</TerminalLabel>
+          <ul aria-label="Themes" className="flex flex-wrap gap-1.5 text-sm">
+            {themes.map((theme) => (
+              <li key={theme}>
+                <Badge variant="secondary" className="rounded-md">{theme}</Badge>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {hasGenres ? (
+        <>
+          <TerminalLabel>{`// GENRES`}</TerminalLabel>
+          <ul aria-label="Genres" className="flex flex-wrap gap-1.5 text-sm">
+            {genres.map((genre) => (
+              <li key={genre}>
+                <Badge variant="secondary" className="rounded-md">{genre}</Badge>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {hasPlatforms ? (
+        <>
+          <TerminalLabel>{`// PLATFORMS`}</TerminalLabel>
+          <div aria-label="Platforms">
+            <PlatformBadges platforms={platforms} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function TerminalLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-muted-foreground font-mono text-xs tracking-wider uppercase">
+      {children}
+    </span>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/themes-tags-panel/themes-tags-panel.type.ts
@@ -1,0 +1,5 @@
+export type ThemesTagsPanelProps = {
+  themes: string[];
+  genres: string[];
+  platforms: string[];
+};

--- a/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/index.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/index.ts
@@ -1,0 +1,2 @@
+export { YourRecordPanel } from "./your-record-panel";
+export type { YourRecordPanelProps } from "./your-record-panel.type";

--- a/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.test.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { YourRecordPanel } from "./your-record-panel";
+
+const invalidate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({ invalidate }),
+}));
+
+const updateLibraryItemFn = vi.fn();
+
+vi.mock("@/features/manage-library-entry/api/update-library-item-fn", () => ({
+  updateLibraryItemFn: (args: unknown) => updateLibraryItemFn(args),
+}));
+
+const onLogSession = vi.fn();
+
+const elements = {
+  queryHeading: () => screen.queryByText("// YOUR RECORD"),
+  queryPlaytimeTerm: () => screen.queryByText("Playtime"),
+  queryPlaytimeValue: () => screen.queryByText("3h"),
+  querySessionsTerm: () => screen.queryByText("Sessions"),
+  querySessionsValue: () => screen.queryByText("7"),
+  getRatingStar: (n: number) => screen.getByTestId(`rating-star-${n}`),
+  queryRating: () => screen.queryByRole("slider"),
+  queryReadOnlyRating: () => screen.queryByRole("img", { name: /rating/i }),
+  getLogSessionButton: () =>
+    screen.getByRole("button", { name: "Log a session" }),
+};
+
+const actions = {
+  clickFourthStar: async () => {
+    await userEvent.click(elements.getRatingStar(4));
+  },
+  clickLogSession: async () => {
+    await userEvent.click(elements.getLogSessionButton());
+  },
+};
+
+describe("YourRecordPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateLibraryItemFn.mockResolvedValue({
+      id: 1,
+      rating: 8,
+      gameId: "game-1",
+    });
+  });
+
+  describe("given an in-library game with logged time and sessions", () => {
+    beforeEach(() => {
+      render(
+        <YourRecordPanel
+          itemId={1}
+          rating={null}
+          playtimeTotalMinutes={180}
+          journalCount={7}
+          gameTitle="Hollow Knight"
+          onLogSession={onLogSession}
+        />
+      );
+    });
+
+    it("renders the YOUR RECORD heading", () => {
+      expect(elements.queryHeading()).not.toBeNull();
+    });
+
+    it("shows the playtime in hours", () => {
+      expect(elements.queryPlaytimeTerm()).not.toBeNull();
+      expect(elements.queryPlaytimeValue()).not.toBeNull();
+    });
+
+    it("shows the sessions count from journalCount", () => {
+      expect(elements.querySessionsTerm()).not.toBeNull();
+      expect(elements.querySessionsValue()).not.toBeNull();
+    });
+
+    it("renders an interactive rating control", () => {
+      expect(elements.queryRating()).not.toBeNull();
+    });
+
+    it("submits a rating change via the mutation", async () => {
+      await actions.clickFourthStar();
+      expect(updateLibraryItemFn).toHaveBeenCalledTimes(1);
+      expect(updateLibraryItemFn).toHaveBeenCalledWith({
+        data: { itemId: 1, rating: 8 },
+      });
+    });
+
+    it("invokes onLogSession when the log button is clicked", async () => {
+      await actions.clickLogSession();
+      expect(onLogSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given no logged time", () => {
+    beforeEach(() => {
+      render(
+        <YourRecordPanel
+          itemId={1}
+          rating={null}
+          playtimeTotalMinutes={0}
+          journalCount={2}
+          gameTitle="Hollow Knight"
+          onLogSession={onLogSession}
+        />
+      );
+    });
+
+    it("omits the playtime figure entirely", () => {
+      expect(elements.queryPlaytimeTerm()).toBeNull();
+    });
+
+    it("still shows the sessions count", () => {
+      expect(elements.querySessionsTerm()).not.toBeNull();
+    });
+  });
+
+  describe("given the game is not in the library", () => {
+    beforeEach(() => {
+      render(
+        <YourRecordPanel
+          itemId={null}
+          rating={null}
+          playtimeTotalMinutes={0}
+          journalCount={0}
+          gameTitle="Hollow Knight"
+          onLogSession={onLogSession}
+        />
+      );
+    });
+
+    it("does not render an interactive rating control", () => {
+      expect(elements.queryRating()).toBeNull();
+    });
+  });
+});

--- a/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.tsx
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.tsx
@@ -1,0 +1,109 @@
+import { useRouter } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { updateLibraryItemFn } from "@/features/manage-library-entry/api/update-library-item-fn";
+import { getErrorMessage } from "@/shared/lib/errors";
+import { Button } from "@/shared/ui/button";
+import { RatingInput } from "@/shared/ui/rating-input";
+
+import type { YourRecordPanelProps } from "./your-record-panel.type";
+
+const MINUTES_PER_HOUR = 60;
+
+function toHours(minutes: number): number {
+  return Math.round(minutes / MINUTES_PER_HOUR);
+}
+
+export function YourRecordPanel({
+  itemId,
+  rating,
+  playtimeTotalMinutes,
+  journalCount,
+  gameTitle,
+  onLogSession,
+}: YourRecordPanelProps) {
+  const router = useRouter();
+  const [optimisticRating, setOptimisticRating] = useState<number | null>(
+    rating
+  );
+  const [pending, setPending] = useState(false);
+
+  const showPlaytime = playtimeTotalMinutes > 0;
+
+  const handleRatingChange = async (next: number | null) => {
+    if (itemId === null || pending) return;
+    const previous = optimisticRating;
+    setOptimisticRating(next);
+    setPending(true);
+    try {
+      const updated = await updateLibraryItemFn({
+        data: { itemId, rating: next },
+      });
+      setOptimisticRating(updated.rating ?? null);
+      await router.invalidate();
+    } catch (err: unknown) {
+      setOptimisticRating(previous);
+      toast.error(getErrorMessage(err, "Something went wrong"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="gap-md flex flex-col" data-testid="your-record-panel">
+      <span className="text-muted-foreground font-mono text-xs tracking-wider uppercase">
+        {`// YOUR RECORD`}
+      </span>
+
+      <div className="gap-sm flex flex-col">
+        {showPlaytime ? (
+          <StatRow
+            term="Playtime"
+            value={`${toHours(playtimeTotalMinutes)}h`}
+          />
+        ) : null}
+        <StatRow term="Sessions" value={String(journalCount)} />
+      </div>
+
+      {itemId !== null ? (
+        <div className="border-border/50 flex items-center justify-between border-t pt-3">
+          <span className="text-muted-foreground text-caption tracking-wider uppercase">
+            Your rating
+          </span>
+          <RatingInput
+            value={optimisticRating}
+            readOnly={false}
+            size="md"
+            onChange={handleRatingChange}
+            aria-label={`Rate ${gameTitle}`}
+          />
+        </div>
+      ) : null}
+
+      <Button
+        type="button"
+        size="sm"
+        className="gap-1.5 self-start"
+        onClick={onLogSession}
+      >
+        <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        Log a session
+      </Button>
+    </div>
+  );
+}
+
+function StatRow({ term, value }: { term: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between">
+      <span className="text-muted-foreground text-caption tracking-wider uppercase">
+        {term}
+      </span>
+      <span className="text-foreground font-mono text-base font-bold">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.type.ts
+++ b/savepoint-tanstack/src/widgets/game-detail/ui/your-record-panel/your-record-panel.type.ts
@@ -1,0 +1,14 @@
+export type YourRecordPanelProps = {
+  /** Library item id, or `null` when the game is not in the viewer's library. */
+  itemId: number | null;
+  /** Current rating (1–10 half-step), or `null` when unrated. */
+  rating: number | null;
+  /** SUM of the viewer's logged playedMinutes; 0 when none (playtime then hidden). */
+  playtimeTotalMinutes: number;
+  /** True count of journal entries — the "sessions" figure. */
+  journalCount: number;
+  /** For the rating control's aria-label. */
+  gameTitle: string;
+  /** Opens the shared compose dialog mounted by the widget. */
+  onLogSession: () => void;
+};

--- a/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.test.tsx
+++ b/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.test.tsx
@@ -47,6 +47,15 @@ vi.mock("@/features/compose-journal-entry/api/create-journal-entry-fn", () => ({
   createJournalEntryFn: vi.fn(),
 }));
 
+// The platform chip renders the abbreviation/icon inside a Badge <div> that
+// carries the variant classes. Walking to the nearest classed ancestor reaches
+// the Badge — mirrors the helper in entities/game/ui/platform-badges.test.tsx.
+const badgeClassNameFor = (text: HTMLElement | null): string => {
+  // eslint-disable-next-line testing-library/no-node-access
+  const badge = text?.closest("[class]");
+  return badge?.className ?? "";
+};
+
 const buildItem = (
   overrides: Partial<LibraryItemWithGame> & {
     gameTitle?: string;
@@ -184,16 +193,17 @@ describe("LibraryItemCard", () => {
         );
       });
 
-      it("renders the platform badge with the full platform label", () => {
-        expect(screen.getByText("PlayStation 5")).toBeDefined();
+      it("renders the platform badge with the abbreviated platform label", () => {
+        expect(screen.getByText("PS5")).toBeDefined();
       });
 
       it("colors the platform badge with the playstation family variant", () => {
-        // The single chosen platform keeps its full label but is now tinted
-        // by family color instead of the neutral `secondary` variant.
-        const badge = screen.getByText("PlayStation 5");
-        expect(badge.className).toContain("text-[#0070d1]");
-        expect(badge.className).not.toContain("bg-secondary");
+        // The platform chip delegates to the shared PlatformBadgeItem, which
+        // abbreviates the label and tints it via the badge `playstation`
+        // variant (brand color) rather than the neutral `subtle` variant.
+        const className = badgeClassNameFor(screen.getByText("PS5"));
+        expect(className).toContain("text-[#0070d1]");
+        expect(className).not.toContain("text-muted-foreground");
       });
 
       it("dates the play window in the lifecycle caption", () => {
@@ -223,9 +233,11 @@ describe("LibraryItemCard", () => {
       });
 
       it("renders the platform badge with the subtle (neutral) variant", () => {
-        const badge = screen.getByText("Stadia");
-        expect(badge.className).toContain("text-muted-foreground");
-        expect(badge.className).not.toContain("text-[#0070d1]");
+        // Stadia has no family mapping, so it keeps its full label and falls
+        // back to the neutral `subtle` badge variant (muted foreground).
+        const className = badgeClassNameFor(screen.getByText("Stadia"));
+        expect(className).toContain("text-muted-foreground");
+        expect(className).not.toContain("text-[#0070d1]");
       });
     });
 

--- a/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.test.tsx
+++ b/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.test.tsx
@@ -184,8 +184,16 @@ describe("LibraryItemCard", () => {
         );
       });
 
-      it("renders the platform badge", () => {
+      it("renders the platform badge with the full platform label", () => {
         expect(screen.getByText("PlayStation 5")).toBeDefined();
+      });
+
+      it("colors the platform badge with the playstation family variant", () => {
+        // The single chosen platform keeps its full label but is now tinted
+        // by family color instead of the neutral `secondary` variant.
+        const badge = screen.getByText("PlayStation 5");
+        expect(badge.className).toContain("text-[#0070d1]");
+        expect(badge.className).not.toContain("bg-secondary");
       });
 
       it("dates the play window in the lifecycle caption", () => {
@@ -202,6 +210,22 @@ describe("LibraryItemCard", () => {
         expect(
           screen.getByRole("button", { name: "Log Session" })
         ).toBeDefined();
+      });
+    });
+
+    describe("given an item on a neutral platform (Stadia)", () => {
+      beforeEach(() => {
+        render(
+          <LibraryItemCard
+            item={buildItem({ status: "PLAYING", platform: "Stadia" })}
+          />
+        );
+      });
+
+      it("renders the platform badge with the subtle (neutral) variant", () => {
+        const badge = screen.getByText("Stadia");
+        expect(badge.className).toContain("text-muted-foreground");
+        expect(badge.className).not.toContain("text-[#0070d1]");
       });
     });
 

--- a/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.tsx
+++ b/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.tsx
@@ -9,11 +9,14 @@ import {
 import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { RatingInput } from "@/shared/ui/rating-input";
+import { TooltipProvider } from "@/shared/ui/tooltip";
+
 import { GameCard } from "@/widgets/game-card";
 
 import { LibraryItemCardCta } from "./library-item-card-cta";
 import type { LibraryItemCardProps } from "./library-item-card.type";
 import { getStatusCoverAccent } from "./library-item-card.utility";
+import { PlatformBadgeItem } from "@/entities/game/ui/platform-badges";
 
 export function LibraryItemCard({ item, menu }: LibraryItemCardProps) {
   const hasPlatform =
@@ -86,12 +89,9 @@ export function LibraryItemCard({ item, menu }: LibraryItemCardProps) {
           data-testid="library-item-card-metadata"
         >
           {hasPlatform ? (
-            <Badge
-              variant="secondary"
-              className="h-4 px-1.5 py-0 text-[10px] leading-none font-medium"
-            >
-              {item.platform}
-            </Badge>
+            <TooltipProvider>
+              <PlatformBadgeItem name={item.platform!} />
+            </TooltipProvider>
           ) : null}
           {showAcquisitionChip ? (
             <Badge
@@ -101,7 +101,7 @@ export function LibraryItemCard({ item, menu }: LibraryItemCardProps) {
               className={cn(
                 "h-4 px-1.5 py-0 text-[10px] leading-none font-medium uppercase",
                 acquisitionEmphasis === "subscription" &&
-                  "bg-primary/10 text-primary border-transparent"
+                "bg-primary/10 text-primary border-transparent"
               )}
             >
               {acquisitionLabel}

--- a/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.tsx
+++ b/savepoint-tanstack/src/widgets/library-item-card/ui/library-item-card/library-item-card.tsx
@@ -1,3 +1,4 @@
+import { PlatformBadgeItem } from "@/entities/game/ui/platform-badges";
 import {
   isTouched,
   LibraryLifecycleStrip,
@@ -10,13 +11,11 @@ import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { RatingInput } from "@/shared/ui/rating-input";
 import { TooltipProvider } from "@/shared/ui/tooltip";
-
 import { GameCard } from "@/widgets/game-card";
 
 import { LibraryItemCardCta } from "./library-item-card-cta";
 import type { LibraryItemCardProps } from "./library-item-card.type";
 import { getStatusCoverAccent } from "./library-item-card.utility";
-import { PlatformBadgeItem } from "@/entities/game/ui/platform-badges";
 
 export function LibraryItemCard({ item, menu }: LibraryItemCardProps) {
   const hasPlatform =
@@ -101,7 +100,7 @@ export function LibraryItemCard({ item, menu }: LibraryItemCardProps) {
               className={cn(
                 "h-4 px-1.5 py-0 text-[10px] leading-none font-medium uppercase",
                 acquisitionEmphasis === "subscription" &&
-                "bg-primary/10 text-primary border-transparent"
+                  "bg-primary/10 text-primary border-transparent"
               )}
             >
               {acquisitionLabel}

--- a/savepoint-tanstack/test/integration/create-journal-entry.integration.test.ts
+++ b/savepoint-tanstack/test/integration/create-journal-entry.integration.test.ts
@@ -317,6 +317,56 @@ describe("createJournalEntry", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Optional playedMinutes (Slice 2 — "Log a session" captures optional minutes)
+  // -------------------------------------------------------------------------
+
+  describe("playedMinutes field", () => {
+    it("persists playedMinutes when provided", async () => {
+      const result = await createJournalEntry("cje-user-owner", {
+        content: "Played for a bit",
+        gameId: "cje-game-a",
+        playedMinutes: 45,
+      });
+
+      expect(result.playedMinutes).toBe(45);
+
+      const row = await db.prisma.journalEntry.findUnique({
+        where: { id: result.id },
+      });
+      expect(row?.playedMinutes).toBe(45);
+    });
+
+    it("stores playedMinutes as null when omitted", async () => {
+      const result = await createJournalEntry("cje-user-owner", {
+        content: "No minutes recorded",
+      });
+
+      expect(result.playedMinutes).toBeNull();
+
+      const row = await db.prisma.journalEntry.findUnique({
+        where: { id: result.id },
+      });
+      expect(row?.playedMinutes).toBeNull();
+    });
+
+    it("records an entry with empty content and no minutes", async () => {
+      const result = await createJournalEntry("cje-user-owner", {
+        content: "",
+      });
+
+      expect(result.content).toBe("");
+      expect(result.playedMinutes).toBeNull();
+
+      const row = await db.prisma.journalEntry.findUnique({
+        where: { id: result.id },
+      });
+      expect(row).not.toBeNull();
+      expect(row?.content).toBe("");
+      expect(row?.playedMinutes).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Isolation — userId is taken from the argument, not input
   // -------------------------------------------------------------------------
 

--- a/savepoint-tanstack/test/integration/get-avatar-presigned-url.integration.test.ts
+++ b/savepoint-tanstack/test/integration/get-avatar-presigned-url.integration.test.ts
@@ -64,26 +64,37 @@ function makeS3Client(): S3Client {
   });
 }
 
-beforeAll(async () => {
-  mockGetServerUserId.mockResolvedValue(TEST_USER_ID);
-
+// LocalStack S3 is an optional local dependency. CI's PR-quality job runs the
+// integration project against Postgres only (no LocalStack service), so this
+// suite skips itself when S3 is unreachable rather than failing the whole run.
+// It still executes in full locally (`docker compose up -d`) and in the
+// dedicated integration workflow that does provision LocalStack.
+//
+// The reachability probe runs at module-collection time (top-level await) so
+// `describe.skipIf` below can read its result before tests are scheduled.
+async function ensureBucketReachable(): Promise<boolean> {
   const s3 = makeS3Client();
   const bucket = process.env.S3_BUCKET_NAME ?? "savepoint-dev";
 
   try {
     await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return true;
   } catch (error: unknown) {
     const err = error as { name?: string };
     if (err.name === "NotFound" || err.name === "NoSuchBucket") {
       await s3.send(new CreateBucketCommand({ Bucket: bucket }));
-    } else {
-      throw new Error(
-        `LocalStack S3 is not reachable at ${process.env.AWS_ENDPOINT_URL ?? "http://localhost:4568"}. ` +
-          `Ensure docker compose is running: docker compose up -d\nCause: ${error}`
-      );
+      return true;
     }
+    // Connection refused / timeout — LocalStack is not running.
+    return false;
   }
-}, 30_000);
+}
+
+const s3Available = await ensureBucketReachable();
+
+beforeAll(() => {
+  mockGetServerUserId.mockResolvedValue(TEST_USER_ID);
+});
 
 afterAll(() => {
   vi.resetAllMocks();
@@ -92,7 +103,7 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe("getAvatarPresignedUrl", () => {
+describe.skipIf(!s3Available)("getAvatarPresignedUrl", () => {
   describe("given a valid image/png payload within the size limit", () => {
     it("returns an object with uploadUrl and publicUrl", async () => {
       const result = await getAvatarPresignedUrl({

--- a/savepoint-tanstack/test/integration/get-avatar-presigned-url.integration.test.ts
+++ b/savepoint-tanstack/test/integration/get-avatar-presigned-url.integration.test.ts
@@ -1,18 +1,12 @@
 /**
- * RED integration test for getAvatarPresignedUrlFn (Slice 6 — Avatar Upload).
+ * Integration test for getAvatarPresignedUrl (Slice 6 — Avatar Upload).
  *
- * This test is intentionally failing: the production module does not exist yet.
- * The import below will throw at module resolution time — that is the expected
- * RED state. Do not implement production code in this file.
- *
- * LocalStack S3 must be reachable at AWS_ENDPOINT_URL (http://localhost:4568).
- * Start with: docker compose up -d
+ * Presigning is a local SigV4 computation — `getSignedUrl` never opens a
+ * network connection — so this suite needs no running S3. It exercises the
+ * full presigned-URL path plus the validation-rejection branches against
+ * static AWS credentials, which makes it deterministic in every environment
+ * (local with or without LocalStack, and the Postgres-only PR-quality CI job).
  */
-import {
-  CreateBucketCommand,
-  HeadBucketCommand,
-  S3Client,
-} from "@aws-sdk/client-s3";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { getServerUserId } from "@/entities/session/api/get-session.server";
@@ -49,49 +43,6 @@ const ALLOWED_MIME_TYPES = [
 const ONE_MB = 1 * 1024 * 1024;
 const TEST_USER_ID = "avatar-presign-integration-user-001";
 
-// ---------------------------------------------------------------------------
-// S3 setup helpers — bucket create-if-not-exists (mirrors canonical test)
-// ---------------------------------------------------------------------------
-function makeS3Client(): S3Client {
-  return new S3Client({
-    region: process.env.AWS_REGION ?? "us-east-1",
-    endpoint: process.env.AWS_ENDPOINT_URL ?? "http://localhost:4568",
-    forcePathStyle: true,
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "test",
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "test",
-    },
-  });
-}
-
-// LocalStack S3 is an optional local dependency. CI's PR-quality job runs the
-// integration project against Postgres only (no LocalStack service), so this
-// suite skips itself when S3 is unreachable rather than failing the whole run.
-// It still executes in full locally (`docker compose up -d`) and in the
-// dedicated integration workflow that does provision LocalStack.
-//
-// The reachability probe runs at module-collection time (top-level await) so
-// `describe.skipIf` below can read its result before tests are scheduled.
-async function ensureBucketReachable(): Promise<boolean> {
-  const s3 = makeS3Client();
-  const bucket = process.env.S3_BUCKET_NAME ?? "savepoint-dev";
-
-  try {
-    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
-    return true;
-  } catch (error: unknown) {
-    const err = error as { name?: string };
-    if (err.name === "NotFound" || err.name === "NoSuchBucket") {
-      await s3.send(new CreateBucketCommand({ Bucket: bucket }));
-      return true;
-    }
-    // Connection refused / timeout — LocalStack is not running.
-    return false;
-  }
-}
-
-const s3Available = await ensureBucketReachable();
-
 beforeAll(() => {
   mockGetServerUserId.mockResolvedValue(TEST_USER_ID);
 });
@@ -103,7 +54,7 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe.skipIf(!s3Available)("getAvatarPresignedUrl", () => {
+describe("getAvatarPresignedUrl", () => {
   describe("given a valid image/png payload within the size limit", () => {
     it("returns an object with uploadUrl and publicUrl", async () => {
       const result = await getAvatarPresignedUrl({

--- a/savepoint-tanstack/test/integration/get-game-details.integration.test.ts
+++ b/savepoint-tanstack/test/integration/get-game-details.integration.test.ts
@@ -414,6 +414,19 @@ describe("getGameDetails", () => {
       expect(result.playtimeTotalMinutes).toBe(expectedSum);
     });
 
+    it("counts only entries with logged minutes, not every journal entry", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
+
+      const expectedWithMinutes = MINUTES_BY_INDEX.filter(
+        (m) => m !== null
+      ).length;
+      expect(result.playtimeSessionCount).toBe(expectedWithMinutes);
+      // The null entries make this strictly smaller than journalCount — the
+      // gap is exactly what would dilute an "average session" computed off
+      // journalCount.
+      expect(result.playtimeSessionCount).toBeLessThan(result.journalCount);
+    });
+
     it("returns the most-recent non-null playedMinutes series oldest→newest, bounded to ~9", async () => {
       const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
 
@@ -460,6 +473,7 @@ describe("getGameDetails", () => {
 
       expect(result.journalCount).toBe(1);
       expect(result.playtimeTotalMinutes).toBe(0);
+      expect(result.playtimeSessionCount).toBe(0);
       expect(result.recentSessionMinutes).toEqual([]);
     });
   });

--- a/savepoint-tanstack/test/integration/get-game-details.integration.test.ts
+++ b/savepoint-tanstack/test/integration/get-game-details.integration.test.ts
@@ -17,9 +17,11 @@
  *   userId?: string;
  * }): Promise<{
  *   game: Game;                    // local Game row (cache-upserted from IGDB)
- *   relatedGames: Game[];          // best-effort; may be []; impl decides strategy
  *   libraryEntry: LibraryItem | null;
  *   journalTeaser: JournalEntry[]; // most recent N (e.g. 3); [] when anon or none
+ *   journalCount: number;          // TRUE count (not capped at the teaser limit)
+ *   playtimeTotalMinutes: number;  // SUM(playedMinutes), null-safe → 0
+ *   recentSessionMinutes: number[]; // recent non-null playedMinutes, oldest→newest, ~9
  * }>
  *
  * Throws NotFoundError when IGDB returns an empty array for the given slug.
@@ -187,7 +189,7 @@ describe("getGameDetails", () => {
   // -------------------------------------------------------------------------
 
   describe("anonymous — no userId provided", () => {
-    it("returns game, relatedGames array, null libraryEntry, and empty journalTeaser", async () => {
+    it("returns the resolved game, null libraryEntry, and empty journalTeaser", async () => {
       const result = await getGameDetails({ slug: GAME_SLUG });
 
       expect(result.game).toBeDefined();
@@ -195,9 +197,16 @@ describe("getGameDetails", () => {
       expect(result.game.igdbId).toBe(IGDB_ID);
       expect(result.game.title).toBe(MOCK_IGDB_GAME.name);
 
-      expect(Array.isArray(result.relatedGames)).toBe(true);
       expect(result.libraryEntry).toBeNull();
       expect(result.journalTeaser).toEqual([]);
+    });
+
+    it("zeroes all personal aggregates for an anonymous viewer", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG });
+
+      expect(result.journalCount).toBe(0);
+      expect(result.playtimeTotalMinutes).toBe(0);
+      expect(result.recentSessionMinutes).toEqual([]);
     });
 
     it("inserts a Game row on cache miss", async () => {
@@ -332,6 +341,143 @@ describe("getGameDetails", () => {
 
       // Most recent entry (index 4) has content "Journal entry 4".
       expect(result.journalTeaser[0]!.content).toBe("Journal entry 4");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Personal aggregates — journalCount, playtimeTotalMinutes, recentSessionMinutes
+  // -------------------------------------------------------------------------
+
+  describe("personal aggregates with more than the teaser limit of entries", () => {
+    const USER_ID = "ggd-user-dave";
+    // playedMinutes for 12 entries in createdAt order (entry 1 = oldest).
+    // Some are null to exercise null-safety and the non-null series filter.
+    const MINUTES_BY_INDEX: Array<number | null> = [
+      30, // 1 (oldest)
+      null, // 2
+      45, // 3
+      60, // 4
+      null, // 5
+      15, // 6
+      90, // 7
+      20, // 8
+      25, // 9
+      35, // 10
+      40, // 11
+      50, // 12 (newest)
+    ];
+
+    beforeEach(async () => {
+      await db.prisma.user.create({ data: makeUser("dave") });
+      await db.prisma.game.create({
+        data: {
+          igdbId: IGDB_ID,
+          title: MOCK_IGDB_GAME.name,
+          slug: GAME_SLUG,
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      });
+      const game = await db.prisma.game.findUnique({
+        where: { slug: GAME_SLUG },
+      });
+      for (let i = 0; i < MINUTES_BY_INDEX.length; i++) {
+        const day = String(i + 1).padStart(2, "0");
+        await db.prisma.journalEntry.create({
+          data: {
+            userId: USER_ID,
+            gameId: game!.id,
+            content: `Journal entry ${i + 1}`,
+            kind: "QUICK",
+            playedMinutes: MINUTES_BY_INDEX[i],
+            createdAt: new Date(`2024-01-${day}T00:00:00.000Z`),
+            updatedAt: new Date(`2024-01-${day}T00:00:00.000Z`),
+          },
+        });
+      }
+    });
+
+    it("returns the true journal count, not capped at the teaser limit", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
+
+      expect(result.journalCount).toBe(MINUTES_BY_INDEX.length);
+      expect(result.journalCount).toBeGreaterThan(result.journalTeaser.length);
+    });
+
+    it("sums playedMinutes across all entries, ignoring nulls", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
+
+      const expectedSum = MINUTES_BY_INDEX.reduce<number>(
+        (acc, m) => acc + (m ?? 0),
+        0
+      );
+      expect(result.playtimeTotalMinutes).toBe(expectedSum);
+    });
+
+    it("returns the most-recent non-null playedMinutes series oldest→newest, bounded to ~9", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
+
+      // Non-null minutes in createdAt order:
+      // 30,45,60,15,90,20,25,35,40,50 (10 values). Bounded to the most recent 9
+      // and presented oldest→newest for a left-to-right rhythm chart.
+      expect(result.recentSessionMinutes).toEqual([
+        45, 60, 15, 90, 20, 25, 35, 40, 50,
+      ]);
+      expect(result.recentSessionMinutes.length).toBeLessThanOrEqual(9);
+    });
+  });
+
+  describe("personal aggregates with entries but no logged minutes", () => {
+    const USER_ID = "ggd-user-erin";
+
+    beforeEach(async () => {
+      await db.prisma.user.create({ data: makeUser("erin") });
+      await db.prisma.game.create({
+        data: {
+          igdbId: IGDB_ID,
+          title: MOCK_IGDB_GAME.name,
+          slug: GAME_SLUG,
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      });
+      const game = await db.prisma.game.findUnique({
+        where: { slug: GAME_SLUG },
+      });
+      await db.prisma.journalEntry.create({
+        data: {
+          userId: USER_ID,
+          gameId: game!.id,
+          content: "No minutes logged",
+          kind: "QUICK",
+          playedMinutes: null,
+        },
+      });
+    });
+
+    it("reports zero total playtime and an empty session series when no minutes are logged", async () => {
+      const result = await getGameDetails({ slug: GAME_SLUG, userId: USER_ID });
+
+      expect(result.journalCount).toBe(1);
+      expect(result.playtimeTotalMinutes).toBe(0);
+      expect(result.recentSessionMinutes).toEqual([]);
+    });
+  });
+
+  describe("signed-in with no entries at all", () => {
+    beforeEach(async () => {
+      await db.prisma.user.create({ data: makeUser("frank") });
+    });
+
+    it("zeroes journalCount, playtime, and the session series", async () => {
+      const result = await getGameDetails({
+        slug: GAME_SLUG,
+        userId: "ggd-user-frank",
+      });
+
+      expect(result.journalCount).toBe(0);
+      expect(result.playtimeTotalMinutes).toBe(0);
+      expect(result.recentSessionMinutes).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

Recomposes the tabbed game-detail page into an inline **bento dashboard** that surfaces information the app already had but hid behind tabs or never showed. Implements spec 023 (`context/spec/023-enriched-game-detail/`). Design rule throughout: **accent color = "you"**, neutral = catalog facts, platform brand colors = platforms. **No database migration** — every field already existed.

## What changed

- **Hero** — critic-score ring (omitted when scoreless), eyebrow (year · publisher · genre, each omit-if-missing), screenshot-or-accent-wash backdrop; in-place **status pill** → popover (desktop) / bottom sheet (mobile), 5 statuses, "Up Next"→"Replay" when played, "Add to library" when not in library.
- **Your Record** — total playtime (omitted when 0), sessions count (true count, fixes the capped-at-3 bug), interactive star rating, "Log a session".
- **Log a session** — `createJournalEntryFn` extended with optional `playedMinutes`; feeds playtime + Your Pace.
- **Times to Beat** — you-vs-benchmark line (accent marker, neutral benchmarks, context sentence; single tick when one benchmark) with a **Your Pace** fallback when no benchmark exists.
- **Screenshots** — strip (grid desktop / rail mobile) + reusable `image-lightbox` (prev/next, ←/→ keys, Esc, thumbnail strip).
- **About / Themes & Tags** — self-omitting panels; family-colored `PlatformBadges`.
- **Platform-badge family colors** adopted on the game card + library card too.
- **Graceful degradation** — hide-never-placeholder, collapse-when-all-absent, title-only-in-library worst case, relax-toward-single-column.

## Data / API

- `getGameDetails` aggregate gains `journalCount`, `playtimeTotalMinutes`, `recentSessionMinutes` (folded into the existing authed `Promise.all`); dead `relatedGames: Game[]` removed.
- `CREATE_JOURNAL_ENTRY_INPUT` gains optional `playedMinutes` (validate-twice).
- Read-path strategy unchanged: core data eager in loader, times-to-beat + related streamed.

## Verification

- unit **1368** ✓ · integration **528** ✓ · typecheck ✓ · lint ✓ · format ✓ · build ✓
- Spec 023 marked **Completed**; roadmap gains a completed enrichment-pass line and annotates backlog #4 (Game Detail Redesign) to reflect the early partial delivery.

## Follow-ups (non-blocking, recorded in tasks.md)

- Authenticated visual sweep of the 5 signed-in surfaces (each is unit-covered).
- Product call: logged-out Times to Beat is currently suppressed for anonymous viewers — confirm or show the bare benchmark.
- Doc nit surfaced: `product-definition.md` says "4 statuses" but the live schema ships 5 (missing UP_NEXT) — candidate for `/awos:product`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game detail rebuilt as an inline bento/card layout with dedicated panels: Screenshots (lightbox with keyboard/thumbnail nav), Journal, Related, About, Themes/Genres/Platforms, Your Record, and Your Pace.
  * Critic score ring and platform-specific badges.

* **Improvements**
  * Times-to-beat replaced with a visual bar and contextual phrasing; Your Pace shows session bars, totals, averages.
  * Optional "Time played (minutes)" when creating journal entries.
  * Streamlined library status flows on desktop and mobile.

* **Documentation**
  * Roadmap updated to note shipped Game Detail enrichment entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->