### PR TITLE
chore(ci): single npm Dependabot config for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: "npm"
-    directory: "/savepoint-tanstack"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-
   - package-ecosystem: "terraform"
     directory: "/infra"
     schedule:


### PR DESCRIPTION
## Problem

Dependabot was opening **duplicate, perpetually-broken npm PRs**. The `.github/dependabot.yml` declared two npm ecosystem entries — `/` and `/savepoint-tanstack` — but this is a **pnpm workspace with a single lockfile** (`pnpm-lock.yaml`) at the repo root.

The `/savepoint-tanstack` entry edited `savepoint-tanstack/package.json` but had no lockfile in that directory to update, leaving the root lockfile stale. Every such PR then failed the **Supply Chain Audit** job with:

> `specifiers in the lockfile don't match specs in package.json` (`pnpm install --frozen-lockfile`)

These PRs could never go green, and where a dep also appeared under the `/` entry they were straight duplicates (e.g. `better-auth`, `react-hook-form`).

## Fix

Keep only the `/` npm entry. It sits next to `pnpm-lock.yaml` + `pnpm-workspace.yaml`, so Dependabot manages the **entire workspace** (member deps included) and updates the one real lockfile correctly. The root config also passed audit on every PR, confirming it's the correct one.

`terraform` (`/infra`) and `github-actions` (`/`) entries are unchanged.

## Follow-up

The 6 broken `/savepoint-tanstack` PRs (#346, #331, #329, #328, #327, #326) are being closed. After this merges, Dependabot will reopen clean root-directory PRs for the deps that were only covered by the member entry (`typescript-eslint`, `@aws-sdk/client-s3`, `@tailwindcss/typography`, `pg`) on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)